### PR TITLE
Hybrid design: port approved brand refresh to Next.js production code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "nitsof-website",
       "version": "0.1.0",
       "dependencies": {
+        "@tailwindcss/typography": "^0.5.19",
+        "@types/marked": "^5.0.2",
+        "gray-matter": "^4.0.3",
+        "marked": "^18.0.3",
         "next": "15.4.1",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -1267,6 +1271,18 @@
         "tailwindcss": "4.1.11"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -1297,6 +1313,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/marked": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.2.tgz",
+      "integrity": "sha512-OucS4KMHhFzhz27KxmWg7J+kIYqyqoW5kdIEI319hqARQQUTqhao3M/F+uFnDXD0Rg72iDDZxZNxq5gvctmLlg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2462,6 +2484,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -3233,6 +3267,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -3285,6 +3332,18 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3621,6 +3680,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -3933,6 +4029,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -4324,6 +4429,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -4781,6 +4895,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -5351,6 +5477,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5637,6 +5776,19 @@
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -5903,6 +6055,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -6098,6 +6256,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6164,7 +6331,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -6460,6 +6626,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.19",
+    "@types/marked": "^5.0.2",
+    "gray-matter": "^4.0.3",
+    "marked": "^18.0.3",
     "next": "15.4.1",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="5" fill="#07080B"/>
+  <text x="4.5" y="24" font-family="system-ui,-apple-system,BlinkMacSystemFont,sans-serif" font-weight="800" font-size="22" fill="#F0EDE8">N</text>
+  <rect x="22" y="4" width="6" height="6" rx="1.5" fill="#1740FF"/>
+</svg>

--- a/public/refresh-preview/README.md
+++ b/public/refresh-preview/README.md
@@ -23,10 +23,19 @@ decisions can be evaluated before any production code is written.
 | Cobalt       | `#1740FF`  | Single saturated accent. Editorial, sharp, replaces the rainbow gradient  |
 | Signal lime  | `#CAFF39`  | Status / "live" / motion accent — used very sparingly                     |
 
-**Display:** Fraunces (variable serif, optical-sized, characterful italic
-for emphasis).
-**Body:** Manrope (variable geometric humanist sans).
-**Mono:** JetBrains Mono (technical labels, ticker, metadata).
+## Typography schemes
+
+The preview supports four switchable typography schemes — toggle them
+via the chip in the top-right corner, or append `?type=` to the URL.
+
+| Key             | Scheme              | Display fonts            | Body / UI                  |
+|-----------------|---------------------|--------------------------|----------------------------|
+| _(default)_ / A | Editorial Bold      | Fraunces                 | Manrope                    |
+| `editorial` / B | Editorial Calm      | Newsreader               | Inter Tight                |
+| `newsstand` / C | Newsstand Contrast  | Instrument Serif         | Inter                      |
+| `swiss` / D     | Swiss Modern        | General Sans             | Switzer                    |
+
+Mono (JetBrains Mono) is shared across all schemes.
 
 ## Notes for review
 

--- a/public/refresh-preview/README.md
+++ b/public/refresh-preview/README.md
@@ -1,0 +1,40 @@
+# NITSOF — Brand refresh preview
+
+A single-file directional concept exploring a refreshed NITSOF identity
+around three values from the brief: **simplicity · confidence · future.**
+
+Open `index.html` directly in any browser, or run the existing site
+locally (`npm run dev`) and visit:
+
+    http://localhost:3000/refresh-preview/
+
+## What this is
+
+A *visualisation*, not a build target. It's intentionally a single HTML
+file so it can be reviewed without touching the React app, and so design
+decisions can be evaluated before any production code is written.
+
+## Aesthetic direction
+
+| Token        | Value      | Why                                                                       |
+|--------------|------------|---------------------------------------------------------------------------|
+| Canvas       | `#F4EFE6`  | Warm cream parchment — confident, tactile, the opposite of generic dark   |
+| Ink          | `#0A0908`  | Near-black with warmth — used for type and ink-block CTAs                 |
+| Cobalt       | `#1740FF`  | Single saturated accent. Editorial, sharp, replaces the rainbow gradient  |
+| Signal lime  | `#CAFF39`  | Status / "live" / motion accent — used very sparingly                     |
+
+**Display:** Fraunces (variable serif, optical-sized, characterful italic
+for emphasis).
+**Body:** Manrope (variable geometric humanist sans).
+**Mono:** JetBrains Mono (technical labels, ticker, metadata).
+
+## Notes for review
+
+- The hero replaces the rainbow gradient with a single typographic
+  statement: *"Software, shipped at the speed of thought."*
+- Every section is numbered (§ Capabilities, § Selected work, § How we
+  work) — borrowed from editorial design to project confidence.
+- Cards invert on hover (cream → ink) instead of glowing — a calmer
+  interaction model.
+- The live ticker and pulsing status dot are the only continuously
+  moving elements; everything else animates only on scroll.

--- a/public/refresh-preview/hybrid.html
+++ b/public/refresh-preview/hybrid.html
@@ -4,8 +4,17 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <meta name="robots" content="noindex" />
-<title>NITSOF — Hybrid Preview</title>
-<meta name="description" content="Directional preview: dark dramatic hero transitions to Swiss Modern cream body." />
+<title>NITSOF — Software, shipped at the speed of thought.</title>
+<meta name="description" content="An AI-native software studio. Four disciplines, one team. Australia · Worldwide." />
+<meta name="theme-color" content="#07080B" />
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='5' fill='%2307080B'/%3E%3Ctext x='4.5' y='24' font-family='system-ui%2C-apple-system%2Csans-serif' font-weight='800' font-size='22' fill='%23F0EDE8'%3EN%3C/text%3E%3Crect x='22' y='4' width='6' height='6' rx='1.5' fill='%231740FF'/%3E%3C/svg%3E" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://nitsof.com" />
+<meta property="og:title" content="NITSOF — Software, shipped at the speed of thought." />
+<meta property="og:description" content="An AI-native software studio. Australia · Worldwide. Currently open for Q3 engagements." />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="NITSOF — Software, shipped at the speed of thought." />
+<meta name="twitter:description" content="An AI-native software studio. Australia · Worldwide." />
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -1027,10 +1036,150 @@ body.past-hero .nav-links a:hover { color: var(--ink); }
   *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
   .reveal { opacity: 1; transform: none; }
 }
+
+/* -------------------------------------------------------------------------
+   SCROLL PROGRESS BAR
+   ------------------------------------------------------------------------- */
+#scroll-progress {
+  position: fixed;
+  top: 0; left: 0;
+  width: 0%;
+  height: 2px;
+  background: var(--cobalt);
+  z-index: 200;
+  transition: width .1s linear;
+  pointer-events: none;
+}
+
+/* -------------------------------------------------------------------------
+   MOBILE HAMBURGER
+   ------------------------------------------------------------------------- */
+.hamburger {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 32px; height: 32px;
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+}
+.hamburger span {
+  display: block;
+  width: 100%; height: 1.5px;
+  background: var(--dark-ink);
+  transition: transform .3s ease, opacity .3s ease, background .5s ease;
+}
+body.past-hero .hamburger span { background: var(--ink); }
+.hamburger.open span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
+.hamburger.open span:nth-child(2) { opacity: 0; }
+.hamburger.open span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
+@media (max-width: 760px) { .hamburger { display: flex; } }
+
+.mobile-menu {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: var(--dark);
+  z-index: 20;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+}
+.mobile-menu.open { display: flex; }
+.mobile-menu a {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.2rem, 10vw, 3.5rem);
+  letter-spacing: -0.04em;
+  color: var(--dark-ink);
+  transition: color .25s ease;
+}
+.mobile-menu a:hover { color: var(--cobalt); }
+.mobile-menu .menu-cta {
+  margin-top: 1rem;
+  display: inline-flex; align-items: center; gap: .6rem;
+  padding: 0.9rem 1.6rem;
+  background: var(--cobalt);
+  color: var(--cream);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+
+/* -------------------------------------------------------------------------
+   CLIENT / TRUSTED-BY STRIP
+   ------------------------------------------------------------------------- */
+.clients {
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 2rem var(--pad);
+  display: flex;
+  align-items: center;
+  gap: clamp(1.5rem, 4vw, 4rem);
+  overflow: hidden;
+  flex-wrap: wrap;
+}
+.clients-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding-right: clamp(1rem, 3vw, 2.5rem);
+  border-right: 1px solid var(--rule);
+}
+.clients-logos {
+  display: flex;
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: center;
+  flex-wrap: wrap;
+}
+.client-name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: clamp(0.8rem, 1.8vw, 1.05rem);
+  letter-spacing: -0.01em;
+  color: var(--ink-mute);
+  transition: color .25s ease;
+  white-space: nowrap;
+}
+.client-name:hover { color: var(--ink); }
+
+/* -------------------------------------------------------------------------
+   FOOTER SOCIAL LINKS
+   ------------------------------------------------------------------------- */
+.footer-social {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+}
+.footer-social a {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  color: var(--ink-mute);
+  transition: color .25s ease;
+}
+.footer-social a:hover { color: var(--ink); }
+.footer-flag {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  color: var(--ink-mute);
+}
 </style>
 </head>
 <body>
 
+<div id="scroll-progress" aria-hidden="true"></div>
 <div class="grain-overlay" aria-hidden="true"></div>
 
 <!-- VARIANT BADGE ---------------------------------------------------------- -->
@@ -1065,7 +1214,22 @@ body.past-hero .nav-links a:hover { color: var(--ink); }
     Start a project
     <svg class="arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
   </a>
+  <button class="hamburger" id="hamburger-btn" aria-label="Open menu" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
 </header>
+
+<!-- MOBILE MENU ------------------------------------------------------------ -->
+<nav class="mobile-menu" id="mobile-menu" aria-hidden="true">
+  <a href="#work" class="mobile-link">Work</a>
+  <a href="#capabilities" class="mobile-link">Capabilities</a>
+  <a href="#process" class="mobile-link">Process</a>
+  <a href="#about" class="mobile-link">Studio</a>
+  <a class="menu-cta" href="#contact">
+    Start a project
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+  </a>
+</nav>
 
 <!-- HERO — dark, full viewport --------------------------------------------- -->
 <section class="hero" id="hero">
@@ -1114,6 +1278,18 @@ body.past-hero .nav-links a:hover { color: var(--ink); }
 
 <!-- BRIDGE — dark fades to cream ------------------------------------------- -->
 <div class="bridge" aria-hidden="true"></div>
+
+<!-- CLIENT STRIP ----------------------------------------------------------- -->
+<div class="clients reveal">
+  <span class="clients-label">Trusted by</span>
+  <div class="clients-logos">
+    <span class="client-name">Apex Logistics</span>
+    <span class="client-name">Stackborn</span>
+    <span class="client-name">Mercia Health</span>
+    <span class="client-name">Nordpath Retail</span>
+    <span class="client-name">LiveCarrierRates</span>
+  </div>
+</div>
 
 <!-- MANIFESTO STRIP -------------------------------------------------------- -->
 <section class="manifesto">
@@ -1324,9 +1500,21 @@ body.past-hero .nav-links a:hover { color: var(--ink); }
 
 <!-- FOOTER ----------------------------------------------------------------- -->
 <footer class="footer">
-  <span>© 2026 NITSOF · All rights reserved</span>
-  <span><a href="/privacy">Privacy</a> · <a href="mailto:hello@nitsof.com">hello@nitsof.com</a></span>
-  <span>Hybrid preview · v0.1</span>
+  <span class="footer-flag">
+    <svg width="14" height="11" viewBox="0 0 14 11" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect width="14" height="11" rx="1" fill="#00008B"/><rect y="0" width="14" height="5.5" fill="#00008B"/><line x1="0" y1="0" x2="14" y2="11" stroke="white" stroke-width="1.8"/><line x1="14" y1="0" x2="0" y2="11" stroke="white" stroke-width="1.8"/><line x1="0" y1="0" x2="14" y2="11" stroke="#CC0000" stroke-width="1"/><line x1="14" y1="0" x2="0" y2="11" stroke="#CC0000" stroke-width="1"/><rect y="4" width="14" height="3" fill="white"/><rect x="5.5" y="0" width="3" height="11" fill="white"/><rect y="4.5" width="14" height="2" fill="#CC0000"/><rect x="6" y="0" width="2" height="11" fill="#CC0000"/></svg>
+    Made in Australia
+  </span>
+  <span>© 2026 NITSOF · <a href="/privacy">Privacy</a> · <a href="mailto:hello@nitsof.com">hello@nitsof.com</a></span>
+  <div class="footer-social">
+    <a href="https://linkedin.com/company/nitsof" target="_blank" rel="noopener" aria-label="LinkedIn">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>
+      LinkedIn
+    </a>
+    <a href="https://github.com/nitsof" target="_blank" rel="noopener" aria-label="GitHub">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+      GitHub
+    </a>
+  </div>
 </footer>
 
 <script>
@@ -1357,6 +1545,42 @@ body.past-hero .nav-links a:hover { color: var(--ink); }
       }
     }, { threshold: 0 });
     if (bridge) bridgeObs.observe(bridge);
+  }
+
+  // Scroll progress bar
+  const progressBar = document.getElementById("scroll-progress");
+  if (progressBar) {
+    window.addEventListener("scroll", () => {
+      const scrolled = window.scrollY;
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      progressBar.style.width = total > 0 ? (scrolled / total * 100) + "%" : "0%";
+    }, { passive: true });
+  }
+
+  // Mobile hamburger
+  const btn = document.getElementById("hamburger-btn");
+  const menu = document.getElementById("mobile-menu");
+  if (btn && menu) {
+    const closeMenu = () => {
+      btn.classList.remove("open");
+      menu.classList.remove("open");
+      btn.setAttribute("aria-expanded", "false");
+      menu.setAttribute("aria-hidden", "true");
+      document.body.style.overflow = "";
+    };
+    btn.addEventListener("click", () => {
+      const isOpen = menu.classList.contains("open");
+      if (isOpen) {
+        closeMenu();
+      } else {
+        btn.classList.add("open");
+        menu.classList.add("open");
+        btn.setAttribute("aria-expanded", "true");
+        menu.setAttribute("aria-hidden", "false");
+        document.body.style.overflow = "hidden";
+      }
+    });
+    menu.querySelectorAll("a").forEach(a => a.addEventListener("click", closeMenu));
   }
 </script>
 </body>

--- a/public/refresh-preview/hybrid.html
+++ b/public/refresh-preview/hybrid.html
@@ -916,6 +916,86 @@ body.past-hero .nav-links a:hover { color: var(--ink); }
 }
 
 /* -------------------------------------------------------------------------
+   INSIGHTS SECTION
+   ------------------------------------------------------------------------- */
+.insights {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 8vw, 6rem) var(--pad);
+  border-top: 1px solid var(--rule);
+}
+.insights-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  margin-top: 3rem;
+}
+@media (min-width: 760px) {
+  .insights-grid { grid-template-columns: repeat(3, 1fr); }
+}
+.insight-card {
+  padding: 2rem 0;
+  border-top: 1px solid var(--rule);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  text-decoration: none;
+  color: var(--ink);
+  transition: none;
+}
+@media (min-width: 760px) {
+  .insight-card { padding: 0 2rem 0 0; border-top: none; border-left: 1px solid var(--rule); }
+  .insight-card:first-child { padding-left: 0; border-left: none; }
+}
+.insight-cat {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--cobalt);
+}
+.insight-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: clamp(1.05rem, 2vw, 1.25rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  transition: color .25s ease;
+}
+.insight-card:hover .insight-title { color: var(--cobalt); }
+.insight-excerpt {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--ink-soft);
+  flex: 1;
+}
+.insight-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-top: 0.4rem;
+}
+.insights-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 2.5rem;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--cobalt);
+  text-decoration: none;
+  border-bottom: 1px solid var(--cobalt);
+  padding-bottom: 2px;
+  transition: opacity .2s ease;
+}
+.insights-all:hover { opacity: 0.7; }
+
+/* -------------------------------------------------------------------------
    CTA BLOCK
    ------------------------------------------------------------------------- */
 .cta {
@@ -929,12 +1009,12 @@ body.past-hero .nav-links a:hover { color: var(--ink); }
   background: var(--ink);
   color: var(--cream);
   border-radius: 8px;
-  padding: clamp(2.5rem, 7vw, 6rem) clamp(2rem, 6vw, 5rem);
+  padding: clamp(2.5rem, 7vw, 5rem) clamp(2rem, 6vw, 5rem);
   display: grid;
   grid-template-columns: 1fr;
   gap: 2.5rem;
 }
-@media (min-width: 900px) { .cta-card { grid-template-columns: 1.4fr 1fr; gap: 4rem; align-items: end; } }
+@media (min-width: 900px) { .cta-card { grid-template-columns: 1fr 1fr; gap: 4rem; align-items: start; } }
 .cta-card::before {
   content: "";
   position: absolute;
@@ -948,40 +1028,99 @@ body.past-hero .nav-links a:hover { color: var(--ink); }
 .cta h2 {
   font-family: var(--font-display);
   font-weight: 700;
-  font-size: clamp(2.2rem, 6vw, 5rem);
+  font-size: clamp(2rem, 5vw, 4rem);
   line-height: 0.95;
   letter-spacing: -0.04em;
   text-wrap: balance;
 }
 .cta h2 em { font-style: normal; color: var(--signal); font-weight: 300; }
 .cta .lead { color: color-mix(in srgb, var(--cream) 75%, transparent); max-width: 36ch; margin-top: 1.5rem; }
-.cta-aside {
+.cta .direct-line {
+  margin-top: 1.5rem;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--cream) 50%, transparent);
+}
+.cta .direct-line a {
+  display: inline;
+  color: color-mix(in srgb, var(--cream) 75%, transparent);
+  transition: color .2s ease;
+}
+.cta .direct-line a:hover { color: var(--signal); }
+.cta-form {
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
-  align-self: end;
+  gap: 1rem;
 }
-.cta-email {
+.cta-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.cta-field label {
   font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.1em;
+  font-size: 10px;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--cream) 55%, transparent);
+  color: color-mix(in srgb, var(--cream) 50%, transparent);
 }
-.cta-email a {
-  display: block;
-  font-family: var(--font-display);
-  text-transform: none;
-  letter-spacing: -0.01em;
-  font-size: clamp(1.2rem, 2.2vw, 1.6rem);
+.cta-field input,
+.cta-field textarea {
+  background: color-mix(in srgb, var(--cream) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--cream) 20%, transparent);
+  border-radius: 4px;
+  padding: 0.75rem 1rem;
   color: var(--cream);
-  font-weight: 500;
-  margin-top: 0.4rem;
-  border-bottom: 1px solid color-mix(in srgb, var(--cream) 30%, transparent);
-  padding-bottom: 0.7rem;
-  transition: color .25s ease, border-color .25s ease;
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color .2s ease;
+  outline: none;
 }
-.cta-email a:hover { color: var(--signal); border-color: var(--signal); }
+.cta-field input:focus,
+.cta-field textarea:focus {
+  border-color: var(--cobalt);
+}
+.cta-field input::placeholder,
+.cta-field textarea::placeholder {
+  color: color-mix(in srgb, var(--cream) 30%, transparent);
+}
+.cta-field textarea { resize: vertical; min-height: 100px; }
+.cta-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.4rem;
+  background: var(--cream);
+  color: var(--ink);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: none;
+  cursor: pointer;
+  width: 100%;
+  transition: transform .25s ease, background .25s ease;
+  margin-top: 0.5rem;
+}
+.cta-submit:hover { background: var(--signal); transform: translateY(-2px); }
+.cta-submit svg { margin-left: auto; }
+.cta-success {
+  display: none;
+  padding: 1.5rem;
+  background: color-mix(in srgb, var(--signal) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--signal) 40%, transparent);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: var(--signal);
+  text-transform: uppercase;
+}
 .cta-btn {
   display: inline-flex;
   align-items: center;
@@ -1209,6 +1348,7 @@ body.past-hero .hamburger span { background: var(--ink); }
     <a href="#capabilities">Capabilities</a>
     <a href="#process">Process</a>
     <a href="#about">Studio</a>
+    <a href="#insights">Insights</a>
   </nav>
   <a class="nav-cta" href="#contact">
     Start a project
@@ -1225,6 +1365,7 @@ body.past-hero .hamburger span { background: var(--ink); }
   <a href="#capabilities" class="mobile-link">Capabilities</a>
   <a href="#process" class="mobile-link">Process</a>
   <a href="#about" class="mobile-link">Studio</a>
+  <a href="#insights" class="mobile-link">Insights</a>
   <a class="menu-cta" href="#contact">
     Start a project
     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
@@ -1478,22 +1619,68 @@ body.past-hero .hamburger span { background: var(--ink); }
   </div>
 </section>
 
+<!-- INSIGHTS SECTION ------------------------------------------------------- -->
+<section class="insights" id="insights">
+  <div class="section-label reveal">§ Insights</div>
+  <h2 class="section-head reveal" style="margin-top:0.8rem">
+    Thinking out loud<br>on software &amp; <em>craft</em>.
+  </h2>
+  <div class="insights-grid">
+    <a class="insight-card reveal" href="/insights/ai-native-delivery">
+      <span class="insight-cat">Engineering</span>
+      <h3 class="insight-title">Why AI-native delivery cuts timelines in half — and what most teams miss</h3>
+      <p class="insight-excerpt">The models aren't the bottleneck. The missing piece is changing how you scope, review, and ship. Here's what two years of AI-first projects taught us.</p>
+      <span class="insight-meta">May 2026 · 6 min read</span>
+    </a>
+    <a class="insight-card reveal" href="/insights/shopify-shipping-complexity">
+      <span class="insight-cat">Product</span>
+      <h3 class="insight-title">The hidden complexity behind Shopify shipping rates</h3>
+      <p class="insight-excerpt">Building Live Carrier Rates taught us that "show the right price at checkout" is deceptively hard. Carrier APIs, real-time latency, and Shopify's rate model all conspire against you.</p>
+      <span class="insight-meta">April 2026 · 8 min read</span>
+    </a>
+    <a class="insight-card reveal" href="/insights/from-prototype-to-production">
+      <span class="insight-cat">Studio</span>
+      <h3 class="insight-title">From prototype to production in four weeks — the NITSOF method</h3>
+      <p class="insight-excerpt">Four weeks isn't a sprint. It's a constraint that forces the right decisions early. This is how we structure engagements so nothing important gets built twice.</p>
+      <span class="insight-meta">March 2026 · 5 min read</span>
+    </a>
+  </div>
+  <a class="insights-all" href="/insights">
+    All insights
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+  </a>
+</section>
+
 <!-- CTA BLOCK -------------------------------------------------------------- -->
 <section class="cta" id="contact">
   <div class="cta-card">
     <div class="reveal">
       <h2>Have something you'd ship if it were <em>easy</em>?</h2>
-      <p class="lead">Tell us what you're trying to build. We respond within one working day with either a plan or an honest reason why we're not the right studio for it.</p>
+      <p class="lead">Tell us what you're trying to build. We respond within one working day — with either a plan or an honest reason why we're not the right studio for it.</p>
+      <p class="direct-line" style="margin-top:2rem">Or email us directly: <a href="mailto:hello@nitsof.com">hello@nitsof.com</a></p>
     </div>
-    <div class="cta-aside reveal">
-      <div class="cta-email">
-        Direct line
-        <a href="mailto:hello@nitsof.com">hello@nitsof.com</a>
+    <div class="reveal">
+      <form class="cta-form" id="contact-form" onsubmit="handleContactSubmit(event)">
+        <div class="cta-field">
+          <label for="cf-name">Your name</label>
+          <input id="cf-name" name="name" type="text" placeholder="Alex Chen" required autocomplete="name">
+        </div>
+        <div class="cta-field">
+          <label for="cf-company">Company or website</label>
+          <input id="cf-company" name="company" type="text" placeholder="acmecorp.com" autocomplete="organization">
+        </div>
+        <div class="cta-field">
+          <label for="cf-message">What are you trying to build?</label>
+          <textarea id="cf-message" name="message" placeholder="We need to ship X by Y and our current approach isn't working because…" required></textarea>
+        </div>
+        <button class="cta-submit" type="submit">
+          Send brief
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </button>
+      </form>
+      <div class="cta-success" id="contact-success">
+        Message sent — we'll be in touch within one working day.
       </div>
-      <a class="cta-btn" href="mailto:hello@nitsof.com">
-        Start a brief
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
-      </a>
     </div>
   </div>
 </section>
@@ -1555,6 +1742,25 @@ body.past-hero .hamburger span { background: var(--ink); }
       const total = document.documentElement.scrollHeight - window.innerHeight;
       progressBar.style.width = total > 0 ? (scrolled / total * 100) + "%" : "0%";
     }, { passive: true });
+  }
+
+  // Contact form — opens pre-filled mailto so the preview works without a backend
+  function handleContactSubmit(e) {
+    e.preventDefault();
+    const data = new FormData(e.target);
+    const name    = data.get("name")    || "";
+    const company = data.get("company") || "";
+    const message = data.get("message") || "";
+    const body = [
+      `Name: ${name}`,
+      company ? `Company: ${company}` : "",
+      "",
+      message,
+    ].filter(Boolean).join("\n");
+    window.location.href = `mailto:hello@nitsof.com?subject=${encodeURIComponent("Project Brief — " + name)}&body=${encodeURIComponent(body)}`;
+    const form    = document.getElementById("contact-form");
+    const success = document.getElementById("contact-success");
+    if (form && success) { form.style.display = "none"; success.style.display = "block"; }
   }
 
   // Mobile hamburger

--- a/public/refresh-preview/hybrid.html
+++ b/public/refresh-preview/hybrid.html
@@ -1,0 +1,1363 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>NITSOF — Hybrid Preview</title>
+<meta name="description" content="Directional preview: dark dramatic hero transitions to Swiss Modern cream body." />
+
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="preconnect" href="https://api.fontshare.com" crossorigin />
+<link rel="preconnect" href="https://cdn.fontshare.com" crossorigin />
+
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" />
+<link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=general-sans@300,400,500,600,700&f[]=switzer@300,400,500,600,700&display=swap" />
+
+<style>
+/* =========================================================================
+   NITSOF — Hybrid preview
+   Dark full-viewport hero → warm cream body (Swiss Modern)
+   Font: General Sans + Switzer + JetBrains Mono
+   Palette hero: near-black / cobalt / signal-lime
+   Palette body: warm cream / ink / cobalt / signal-lime
+   ========================================================================= */
+
+:root {
+  /* Body palette (Swiss Modern) */
+  --cream:        #F4EFE6;
+  --cream-deep:   #ECE6D7;
+  --ink:          #0A0908;
+  --ink-soft:     #1A1816;
+  --ink-mute:     #6C6660;
+  --rule:         rgba(10,9,8,.1);
+  --rule-light:   rgba(10,9,8,.06);
+  --cobalt:       #1740FF;
+  --cobalt-deep:  #0A1E8A;
+  --signal:       #CAFF39;
+
+  /* Hero palette (dark) */
+  --dark:         #07080B;
+  --dark-surface: #0D0F14;
+  --dark-ink:     #F0EDE8;
+  --dark-mute:    rgba(240,237,232,.45);
+  --dark-rule:    rgba(240,237,232,.08);
+  --dark-rule-s:  rgba(240,237,232,.13);
+  --cobalt-glow:  rgba(23,64,255,.28);
+  --signal-soft:  rgba(202,255,57,.18);
+
+  --pad: clamp(1.25rem, 4vw, 3rem);
+  --max: 1440px;
+
+  --font-display: "General Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-body:    "Switzer", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+body {
+  font-family: var(--font-body);
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.55;
+  background: var(--cream);
+  color: var(--ink);
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Warm grain on cream sections */
+.grain-overlay {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  opacity: 0;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.04  0 0 0 0 0.035  0 0 0 0 0.03  0 0 0 0.4 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  transition: opacity .6s ease;
+}
+body.past-hero .grain-overlay { opacity: .32; }
+
+a { color: inherit; text-decoration: none; }
+button { font: inherit; cursor: pointer; }
+::selection { background: var(--cobalt); color: var(--cream); }
+
+/* -------------------------------------------------------------------------
+   VARIANT BADGE
+   ------------------------------------------------------------------------- */
+.variant-badge {
+  position: fixed;
+  top: 0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 90;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.75rem;
+  background: var(--cobalt);
+  color: var(--cream);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+/* -------------------------------------------------------------------------
+   TICKER — dark themed
+   ------------------------------------------------------------------------- */
+.ticker {
+  position: relative;
+  z-index: 30;
+  border-bottom: 1px solid var(--dark-rule);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--dark-mute);
+  overflow: hidden;
+  background: var(--dark);
+}
+.ticker-track {
+  display: flex;
+  gap: 3rem;
+  white-space: nowrap;
+  padding: 0.65rem 0;
+  width: max-content;
+  animation: ticker-scroll 60s linear infinite;
+}
+.ticker-item { display: inline-flex; align-items: center; gap: .6rem; }
+.ticker-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: rgba(240,237,232,.2);
+}
+.ticker-item--live .ticker-dot {
+  background: var(--signal);
+  opacity: 1;
+  box-shadow: 0 0 0 4px var(--signal-soft);
+  animation: pulse 1.8s ease-in-out infinite;
+}
+.ticker-item strong { color: var(--dark-ink); font-weight: 500; }
+@keyframes ticker-scroll { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 4px var(--signal-soft); }
+  50%       { box-shadow: 0 0 0 9px rgba(202,255,57,0); }
+}
+
+/* -------------------------------------------------------------------------
+   NAV — dark initially, transitions to cream after hero
+   ------------------------------------------------------------------------- */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 25;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 2rem;
+  padding: 1.1rem var(--pad);
+  background: color-mix(in srgb, var(--dark) 88%, transparent);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--dark-rule);
+  transition: background .5s ease, border-color .5s ease;
+}
+body.past-hero .nav {
+  background: color-mix(in srgb, var(--cream) 88%, transparent);
+  border-bottom-color: var(--rule);
+}
+.wordmark {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  color: var(--dark-ink);
+  transition: color .5s ease;
+}
+body.past-hero .wordmark { color: var(--ink); }
+.wordmark .dot {
+  width: 8px; height: 8px;
+  background: var(--cobalt);
+  border-radius: 1px;
+  transform: translateY(-2px);
+}
+.nav-links {
+  display: flex;
+  justify-self: center;
+  gap: 2.25rem;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.nav-links a {
+  position: relative;
+  padding: 0.25rem 0;
+  color: var(--dark-mute);
+  transition: color .3s ease;
+}
+.nav-links a:hover { color: var(--dark-ink); }
+body.past-hero .nav-links a { color: var(--ink-mute); }
+body.past-hero .nav-links a:hover { color: var(--ink); }
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -2px;
+  height: 1px;
+  background: var(--cobalt);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform .35s cubic-bezier(.2,.7,.2,1);
+}
+.nav-links a:hover::after { transform: scaleX(1); }
+@media (max-width: 760px) { .nav-links { display: none; } }
+
+.nav-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: .6rem;
+  padding: 0.55rem 1rem;
+  background: var(--cobalt);
+  color: var(--cream);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform .25s ease, opacity .25s ease;
+}
+.nav-cta:hover { opacity: .85; transform: translateY(-1px); }
+.nav-cta .arrow { transition: transform .25s ease; }
+.nav-cta:hover .arrow { transform: translateX(3px); }
+
+/* -------------------------------------------------------------------------
+   HERO — dark, full-viewport, content anchored to bottom
+   ------------------------------------------------------------------------- */
+.hero {
+  position: relative;
+  min-height: 94vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  overflow: hidden;
+  background: var(--dark);
+}
+
+/* Fine grid */
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--dark-rule) 1px, transparent 1px),
+    linear-gradient(90deg, var(--dark-rule) 1px, transparent 1px);
+  background-size: 72px 72px;
+  pointer-events: none;
+  z-index: 0;
+  mask-image: linear-gradient(to bottom, transparent 0%, black 20%, black 60%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 20%, black 60%, transparent 100%);
+}
+
+/* Cobalt glow at top-right */
+.hero-glow {
+  position: absolute;
+  top: -15%;
+  right: -8%;
+  width: 65vw;
+  height: 65vw;
+  background: radial-gradient(circle, var(--cobalt-glow) 0%, transparent 60%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Secondary signal-lime glow bottom-left */
+.hero-glow-2 {
+  position: absolute;
+  bottom: -10%;
+  left: -5%;
+  width: 40vw;
+  height: 40vw;
+  background: radial-gradient(circle, rgba(202,255,57,.06) 0%, transparent 65%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hero-inner {
+  position: relative;
+  z-index: 2;
+  max-width: var(--max);
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 var(--pad);
+}
+
+.hero-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--cobalt);
+  margin-bottom: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+}
+.hero-eyebrow::before {
+  content: "";
+  width: 32px; height: 1px;
+  background: var(--cobalt);
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.hero h1 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(3rem, 9.5vw, 9.5rem);
+  line-height: 0.92;
+  letter-spacing: -0.04em;
+  color: var(--dark-ink);
+  margin-bottom: clamp(2.5rem, 5vw, 4rem);
+  text-wrap: balance;
+}
+.hero h1 em {
+  font-style: normal;
+  font-weight: 300;
+  color: var(--cobalt);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: clamp(3rem, 5vw, 4.5rem);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 1.05rem 1.6rem;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform .3s cubic-bezier(.2,.7,.2,1), background .25s ease, color .25s ease, opacity .25s ease;
+}
+.btn--primary {
+  background: var(--cobalt);
+  color: var(--cream);
+}
+.btn--primary:hover { opacity: .85; transform: translateY(-2px); }
+.btn--ghost {
+  border: 1px solid var(--dark-rule-s);
+  color: rgba(240,237,232,.7);
+}
+.btn--ghost:hover { border-color: var(--dark-ink); color: var(--dark-ink); transform: translateY(-2px); }
+
+/* Stat bar at base of hero */
+.hero-bar {
+  border-top: 1px solid var(--dark-rule);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  max-width: var(--max);
+  width: 100%;
+  margin: 0 auto;
+  position: relative;
+  z-index: 2;
+}
+@media (max-width: 640px) {
+  .hero-bar { grid-template-columns: 1fr 1fr; }
+}
+.hero-stat {
+  padding: 1.4rem 0;
+  padding-right: 1.5rem;
+  border-right: 1px solid var(--dark-rule);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding-left: var(--pad);
+}
+.hero-stat:first-child { padding-left: var(--pad); }
+.hero-stat:last-child { border-right: 0; }
+.hero-stat + .hero-stat { padding-left: 1.5rem; }
+.stat-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--dark-mute);
+}
+.stat-value {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--dark-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  letter-spacing: -0.01em;
+}
+.live-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--signal);
+  box-shadow: 0 0 0 3px var(--signal-soft);
+  flex-shrink: 0;
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+/* -------------------------------------------------------------------------
+   TRANSITION BRIDGE — dark fades to cream
+   ------------------------------------------------------------------------- */
+.bridge {
+  height: clamp(5rem, 10vw, 8rem);
+  background: linear-gradient(to bottom, var(--dark) 0%, var(--cream) 100%);
+}
+
+/* -------------------------------------------------------------------------
+   MANIFESTO — cream, 3-column cards
+   ------------------------------------------------------------------------- */
+.manifesto {
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  background: var(--cream-deep);
+  overflow: hidden;
+}
+.manifesto-inner {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 3.5rem) var(--pad);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+}
+@media (min-width: 900px) {
+  .manifesto-inner { grid-template-columns: repeat(3, 1fr); gap: 3rem; }
+}
+.principle {
+  position: relative;
+  padding-top: 1.4rem;
+  border-top: 1px solid var(--ink);
+}
+.principle-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--ink-mute);
+  position: absolute;
+  top: 1.4rem; right: 0;
+}
+.principle h3 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(1.9rem, 3.5vw, 2.6rem);
+  line-height: 1;
+  letter-spacing: -0.03em;
+  margin-bottom: 1rem;
+}
+.principle h3 em { font-style: normal; color: var(--cobalt); font-weight: 300; }
+.principle p {
+  font-size: 0.95rem;
+  color: var(--ink-soft);
+  max-width: 32ch;
+}
+
+/* -------------------------------------------------------------------------
+   SHARED SECTION SCAFFOLDING
+   ------------------------------------------------------------------------- */
+.section {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 9vw, 7rem) var(--pad);
+}
+.section-head {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  margin-bottom: clamp(3rem, 6vw, 5rem);
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  align-items: end;
+}
+@media (min-width: 900px) {
+  .section-head { grid-template-columns: auto 1fr auto; gap: 3rem; }
+}
+.section-head .label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-mute);
+}
+.section-head h2 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  letter-spacing: -0.04em;
+  line-height: 1;
+  text-wrap: balance;
+}
+.section-head h2 em { font-style: normal; color: var(--cobalt); font-weight: 300; }
+.section-head .aside {
+  font-size: 0.9rem;
+  max-width: 26ch;
+  color: var(--ink-mute);
+  align-self: end;
+}
+
+/* -------------------------------------------------------------------------
+   CAPABILITIES
+   ------------------------------------------------------------------------- */
+.capabilities {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+}
+@media (min-width: 720px) { .capabilities { grid-template-columns: 1fr 1fr; } }
+@media (min-width: 1100px) { .capabilities { grid-template-columns: repeat(4, 1fr); } }
+
+.cap {
+  background: var(--cream);
+  padding: 2rem 1.8rem 2.5rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  min-height: 320px;
+  transition: background .35s ease, color .35s ease;
+}
+.cap:hover { background: var(--ink); color: var(--cream); }
+.cap:hover .cap-num,
+.cap:hover .cap-desc { color: color-mix(in srgb, var(--cream) 75%, transparent); }
+.cap:hover .cap-arrow { transform: translate(6px, -6px); color: var(--signal); }
+
+.cap-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  color: var(--ink-mute);
+  transition: color .35s ease;
+}
+.cap h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.5rem;
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  margin-top: auto;
+}
+.cap-desc {
+  font-size: 0.92rem;
+  color: var(--ink-soft);
+  transition: color .35s ease;
+  max-width: 30ch;
+}
+.cap-arrow {
+  position: absolute;
+  top: 1.8rem; right: 1.8rem;
+  width: 20px; height: 20px;
+  color: var(--ink-mute);
+  transition: transform .35s cubic-bezier(.2,.7,.2,1), color .35s ease;
+}
+
+/* -------------------------------------------------------------------------
+   SELECTED WORK
+   ------------------------------------------------------------------------- */
+.work {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+}
+@media (min-width: 960px) { .work { grid-template-columns: 1fr 1fr; gap: 2rem; } }
+
+.case {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+.case-frame {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--ink);
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  border: 1px solid var(--rule);
+  transition: transform .5s cubic-bezier(.2,.7,.2,1);
+}
+.case:hover .case-frame { transform: translateY(-6px); }
+.case-frame--carrier { background: linear-gradient(155deg, #0b153f 0%, #0a0908 60%); }
+.case-frame--sku     { background: linear-gradient(155deg, #1a1816 0%, #0a0908 70%); }
+
+.window-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: color-mix(in srgb, var(--cream) 50%, transparent);
+}
+.window-bar .dots { display: flex; gap: 5px; }
+.window-bar .dots span {
+  width: 9px; height: 9px; border-radius: 50%;
+  background: color-mix(in srgb, var(--cream) 18%, transparent);
+}
+.window-bar .url {
+  margin-left: 0.9rem;
+  padding: 0.2rem 0.65rem;
+  background: color-mix(in srgb, var(--cream) 8%, transparent);
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+}
+
+/* Carrier Rates mock checkout */
+.checkout {
+  flex: 1;
+  background: var(--cream);
+  border-radius: 4px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  color: var(--ink);
+}
+.checkout-title {
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.checkout-title small {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.rate {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.55rem 0.7rem;
+  background: var(--cream-deep);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.rate--active {
+  background: var(--ink);
+  color: var(--cream);
+  outline: 2px solid var(--cobalt);
+  outline-offset: -2px;
+}
+.rate strong { font-weight: 500; letter-spacing: 0.02em; }
+.rate-eta { color: var(--ink-mute); font-size: 9px; }
+.rate--active .rate-eta { color: color-mix(in srgb, var(--cream) 60%, transparent); }
+.rate-price {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+/* SKU manager mock dashboard */
+.dash {
+  flex: 1;
+  background: var(--cream);
+  border-radius: 4px;
+  padding: 0.8rem;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 0.55rem;
+  color: var(--ink);
+}
+.dash-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.dash-head small {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.dash-table {
+  display: grid;
+  grid-template-columns: 1fr 0.6fr 0.5fr 0.5fr;
+  gap: 0.3rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  align-content: start;
+}
+.dash-table .th {
+  font-family: var(--font-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  font-size: 8.5px;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--rule);
+}
+.dash-table .td {
+  padding: 0.32rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+.dash-table .pill {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 8px;
+  letter-spacing: 0.04em;
+}
+.pill--live  { background: color-mix(in srgb, var(--signal) 40%, var(--cream)); color: var(--ink); }
+.pill--draft { background: var(--cream-deep); color: var(--ink-mute); }
+
+.case-meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+  align-items: baseline;
+}
+.case-status {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+}
+.case-status .dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--signal);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--signal) 35%, transparent);
+}
+.case-name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.65rem;
+  letter-spacing: -0.03em;
+  line-height: 1;
+}
+.case-desc { color: var(--ink-soft); font-size: 0.95rem; max-width: 50ch; }
+.case-link {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: .55rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--ink);
+  width: fit-content;
+  transition: gap .25s ease, color .25s ease, border-color .25s ease;
+}
+.case-link:hover { gap: .85rem; color: var(--cobalt); border-color: var(--cobalt); }
+
+/* -------------------------------------------------------------------------
+   PROCESS — dark section (intentional return to dark for rhythm)
+   ------------------------------------------------------------------------- */
+.process {
+  background: var(--ink);
+  color: var(--cream);
+  position: relative;
+  overflow: hidden;
+}
+.process::after {
+  content: "";
+  position: absolute;
+  right: -10%;
+  top: -20%;
+  width: 50vw; height: 50vw;
+  border-radius: 50%;
+  background: radial-gradient(circle, color-mix(in srgb, var(--cobalt) 30%, transparent), transparent 65%);
+  pointer-events: none;
+}
+.process-inner {
+  position: relative; z-index: 2;
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 9vw, 7rem) var(--pad);
+}
+.process-head h2 { color: var(--cream); }
+.process-head .label { color: color-mix(in srgb, var(--cream) 55%, transparent); }
+.process-head .aside { color: color-mix(in srgb, var(--cream) 60%, transparent); }
+.process-head { border-color: color-mix(in srgb, var(--cream) 15%, transparent); }
+
+.timeline {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: color-mix(in srgb, var(--cream) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--cream) 12%, transparent);
+}
+@media (min-width: 820px) { .timeline { grid-template-columns: repeat(4, 1fr); } }
+
+.step {
+  background: var(--ink);
+  padding: 2rem 1.8rem 2.4rem;
+  display: flex; flex-direction: column; gap: 0.8rem;
+  position: relative;
+  min-height: 240px;
+}
+.step-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: color-mix(in srgb, var(--cream) 45%, transparent);
+}
+.step h4 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.5rem;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+  color: var(--cream);
+}
+.step h4 em { color: var(--signal); font-style: normal; font-weight: 300; }
+.step p {
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--cream) 65%, transparent);
+  max-width: 30ch;
+  margin-top: auto;
+}
+
+/* -------------------------------------------------------------------------
+   PULL QUOTE
+   ------------------------------------------------------------------------- */
+.pullquote {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 10vw, 8rem) var(--pad);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+}
+@media (min-width: 900px) {
+  .pullquote { grid-template-columns: minmax(0,1fr) 18rem; gap: 4rem; align-items: end; }
+}
+.pullquote blockquote {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(1.8rem, 4.5vw, 3.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  text-wrap: balance;
+}
+.pullquote blockquote em { font-style: normal; color: var(--cobalt); font-weight: 700; }
+.attribution {
+  border-top: 1px solid var(--ink);
+  padding-top: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.attribution .name { font-family: var(--font-display); font-weight: 600; font-size: 1rem; letter-spacing: -0.01em; }
+.attribution .role {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.attribution .others {
+  margin-top: 0.9rem;
+  display: flex; flex-direction: column; gap: 0.3rem;
+  font-size: 0.85rem;
+  color: var(--ink-soft);
+}
+.attribution .others .o {
+  display: flex; justify-content: space-between; gap: 1rem;
+  border-bottom: 1px dashed var(--rule);
+  padding-bottom: 0.3rem;
+}
+.attribution .others .o span:last-child {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
+/* -------------------------------------------------------------------------
+   CTA BLOCK
+   ------------------------------------------------------------------------- */
+.cta {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 0 var(--pad) clamp(4rem, 8vw, 6rem);
+}
+.cta-card {
+  position: relative;
+  overflow: hidden;
+  background: var(--ink);
+  color: var(--cream);
+  border-radius: 8px;
+  padding: clamp(2.5rem, 7vw, 6rem) clamp(2rem, 6vw, 5rem);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+}
+@media (min-width: 900px) { .cta-card { grid-template-columns: 1.4fr 1fr; gap: 4rem; align-items: end; } }
+.cta-card::before {
+  content: "";
+  position: absolute;
+  left: -10%; bottom: -60%;
+  width: 60vw; height: 60vw;
+  background: radial-gradient(circle, color-mix(in srgb, var(--cobalt) 70%, transparent), transparent 60%);
+  pointer-events: none;
+  filter: blur(20px);
+}
+.cta-card > * { position: relative; z-index: 2; }
+.cta h2 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.2rem, 6vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  text-wrap: balance;
+}
+.cta h2 em { font-style: normal; color: var(--signal); font-weight: 300; }
+.cta .lead { color: color-mix(in srgb, var(--cream) 75%, transparent); max-width: 36ch; margin-top: 1.5rem; }
+.cta-aside {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  align-self: end;
+}
+.cta-email {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--cream) 55%, transparent);
+}
+.cta-email a {
+  display: block;
+  font-family: var(--font-display);
+  text-transform: none;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.2rem, 2.2vw, 1.6rem);
+  color: var(--cream);
+  font-weight: 500;
+  margin-top: 0.4rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--cream) 30%, transparent);
+  padding-bottom: 0.7rem;
+  transition: color .25s ease, border-color .25s ease;
+}
+.cta-email a:hover { color: var(--signal); border-color: var(--signal); }
+.cta-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.4rem;
+  background: var(--cream);
+  color: var(--ink);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform .25s ease, background .25s ease;
+}
+.cta-btn:hover { background: var(--signal); transform: translateY(-2px); }
+.cta-btn svg { margin-left: 1.2rem; }
+
+/* -------------------------------------------------------------------------
+   FOOTER
+   ------------------------------------------------------------------------- */
+.footer {
+  border-top: 1px solid var(--rule);
+  padding: 2.5rem var(--pad);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  max-width: var(--max);
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+}
+.footer a:hover { color: var(--ink); }
+
+/* -------------------------------------------------------------------------
+   REVEAL ANIMATIONS
+   ------------------------------------------------------------------------- */
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity .9s cubic-bezier(.2,.7,.2,1), transform .9s cubic-bezier(.2,.7,.2,1);
+}
+.reveal.in { opacity: 1; transform: translateY(0); }
+.reveal:nth-child(2) { transition-delay: 0.08s; }
+.reveal:nth-child(3) { transition-delay: 0.16s; }
+.reveal:nth-child(4) { transition-delay: 0.24s; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
+  .reveal { opacity: 1; transform: none; }
+}
+</style>
+</head>
+<body>
+
+<div class="grain-overlay" aria-hidden="true"></div>
+
+<!-- VARIANT BADGE ---------------------------------------------------------- -->
+<div class="variant-badge" aria-hidden="true">Hybrid — Dark hero · Swiss Modern body</div>
+
+<!-- TICKER — dark themed --------------------------------------------------- -->
+<div class="ticker" aria-hidden="true">
+  <div class="ticker-track">
+    <span class="ticker-item ticker-item--live"><span class="ticker-dot"></span> <strong>Now shipping</strong> · Carrier Rates v2.1 — live in 240+ stores</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> AI-augmented delivery · est. 2024</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Currently accepting Q3 engagements</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Software ↔ thought · velocity 4.2×</span>
+    <span class="ticker-item ticker-item--live"><span class="ticker-dot"></span> <strong>Now shipping</strong> · Carrier Rates v2.1 — live in 240+ stores</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> AI-augmented delivery · est. 2024</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Currently accepting Q3 engagements</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Software ↔ thought · velocity 4.2×</span>
+  </div>
+</div>
+
+<!-- HEADER ----------------------------------------------------------------- -->
+<header class="nav">
+  <a class="wordmark" href="#">
+    NITSOF<span class="dot" aria-hidden="true"></span>
+  </a>
+  <nav class="nav-links">
+    <a href="#work">Work</a>
+    <a href="#capabilities">Capabilities</a>
+    <a href="#process">Process</a>
+    <a href="#about">Studio</a>
+  </nav>
+  <a class="nav-cta" href="#contact">
+    Start a project
+    <svg class="arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+  </a>
+</header>
+
+<!-- HERO — dark, full viewport --------------------------------------------- -->
+<section class="hero" id="hero">
+  <div class="hero-glow" aria-hidden="true"></div>
+  <div class="hero-glow-2" aria-hidden="true"></div>
+
+  <div class="hero-inner">
+    <p class="hero-eyebrow reveal">An AI-native software studio</p>
+    <h1 class="reveal">
+      Software,<br>
+      shipped at the speed<br>
+      of <em>thought</em>.
+    </h1>
+
+    <div class="hero-actions reveal">
+      <a class="btn btn--primary" href="#work">
+        See selected work
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+      </a>
+      <a class="btn btn--ghost" href="#contact">
+        Begin a project
+      </a>
+    </div>
+  </div>
+
+  <!-- stat bar anchored to base -->
+  <div class="hero-bar" id="hero-bottom">
+    <div class="hero-stat">
+      <span class="stat-label">Capacity</span>
+      <span class="stat-value"><span class="live-dot"></span> Open · Q3 2026</span>
+    </div>
+    <div class="hero-stat">
+      <span class="stat-label">From</span>
+      <span class="stat-value">Australia · Worldwide</span>
+    </div>
+    <div class="hero-stat">
+      <span class="stat-label">Est.</span>
+      <span class="stat-value">2024</span>
+    </div>
+    <div class="hero-stat">
+      <span class="stat-label">Velocity</span>
+      <span class="stat-value">4.2× faster delivery</span>
+    </div>
+  </div>
+</section>
+
+<!-- BRIDGE — dark fades to cream ------------------------------------------- -->
+<div class="bridge" aria-hidden="true"></div>
+
+<!-- MANIFESTO STRIP -------------------------------------------------------- -->
+<section class="manifesto">
+  <div class="manifesto-inner">
+    <div class="principle reveal">
+      <span class="principle-num">01 — Principle</span>
+      <h3>Simplicity is <em>the</em> feature.</h3>
+      <p>We strip out everything that doesn't earn its place. Fewer dependencies, fewer screens, fewer meetings. The shortest path from problem to production.</p>
+    </div>
+    <div class="principle reveal">
+      <span class="principle-num">02 — Principle</span>
+      <h3>Confidence in <em>craft</em>.</h3>
+      <p>We don't ship demos. We ship software our clients depend on to run their business — measured in uptime, revenue, and the quality of a sleepless night avoided.</p>
+    </div>
+    <div class="principle reveal">
+      <span class="principle-num">03 — Principle</span>
+      <h3>Building the <em>future</em>, now.</h3>
+      <p>AI sits inside our delivery loop, not as a feature on a slide. The pace this enables is the only thing that lets a four-person team out-ship a fifty-person one.</p>
+    </div>
+  </div>
+</section>
+
+<!-- CAPABILITIES ----------------------------------------------------------- -->
+<section class="section" id="capabilities">
+  <div class="section-head">
+    <span class="label">§ Capabilities</span>
+    <h2>Four disciplines, <em>one</em> studio.</h2>
+    <p class="aside">Each engagement is led by a senior engineer who stays through delivery. No handoffs, no juniors learning on your time.</p>
+  </div>
+
+  <div class="capabilities">
+    <article class="cap reveal">
+      <span class="cap-num">01 / Strategy</span>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 17L17 7M9 7h8v8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <h3>Product archaeology.</h3>
+      <p class="cap-desc">We map what's actually there before adding anything new — most teams already have 70% of what they need, just badly arranged.</p>
+    </article>
+    <article class="cap reveal">
+      <span class="cap-num">02 / Build</span>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 17L17 7M9 7h8v8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <h3>AI-augmented engineering.</h3>
+      <p class="cap-desc">Senior engineers paired with AI throughout — design, code, review, QA. Same craft, 3–5× the throughput.</p>
+    </article>
+    <article class="cap reveal">
+      <span class="cap-num">03 / Ship</span>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 17L17 7M9 7h8v8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <h3>Production from day one.</h3>
+      <p class="cap-desc">Every commit deploys. No staging-forever environments — real users, real load, measured from the first week.</p>
+    </article>
+    <article class="cap reveal">
+      <span class="cap-num">04 / Iterate</span>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 17L17 7M9 7h8v8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <h3>Stay in the loop.</h3>
+      <p class="cap-desc">We don't disappear at launch. Monthly cadence, real metrics, the kind of partner you keep on speed dial.</p>
+    </article>
+  </div>
+</section>
+
+<!-- SELECTED WORK ---------------------------------------------------------- -->
+<section class="section" id="work" style="padding-top: 0;">
+  <div class="section-head">
+    <span class="label">§ Selected work</span>
+    <h2>Built in <em>production</em>. Not in a deck.</h2>
+    <p class="aside">A small selection of the studio's recent work. Full case studies on request.</p>
+  </div>
+
+  <div class="work">
+    <article class="case reveal">
+      <div class="case-frame case-frame--carrier">
+        <div class="window-bar">
+          <div class="dots"><span></span><span></span><span></span></div>
+          <div class="url">checkout.acme-store.com</div>
+        </div>
+        <div class="checkout">
+          <div class="checkout-title">Shipping <small>Step 2 of 3</small></div>
+          <div class="rate">
+            <div><strong>USPS Ground Advantage · 3–5 day tracked</strong><div class="rate-eta">Arrives Mon 25 May</div></div>
+            <div class="rate-price">$4.85</div>
+          </div>
+          <div class="rate rate--active">
+            <div><strong>FedEx Priority Overnight · before 12:00</strong><div class="rate-eta">Arrives Wed 20 May</div></div>
+            <div class="rate-price">$24.40</div>
+          </div>
+          <div class="rate">
+            <div><strong>Australia Post · Express 2 day</strong><div class="rate-eta">Arrives Thu 21 May</div></div>
+            <div class="rate-price">$7.60</div>
+          </div>
+          <div class="rate">
+            <div><strong>DHL Express Worldwide</strong><div class="rate-eta">Arrives Fri 22 May</div></div>
+            <div class="rate-price">$32.50</div>
+          </div>
+        </div>
+      </div>
+      <div class="case-meta">
+        <span class="case-status"><span class="dot"></span> Live</span>
+        <div></div>
+        <h3 class="case-name" style="grid-column: 1 / -1;">Live Carrier Rates</h3>
+        <p class="case-desc" style="grid-column: 1 / -1;">A published Shopify app that surfaces real-time carrier pricing inside checkout — the moment shoppers decide to buy or bail.</p>
+        <a class="case-link" href="https://apps.shopify.com/live-carrier-rates" target="_blank" rel="noopener" style="grid-column: 1 / -1;">
+          View on the Shopify App Store
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </a>
+      </div>
+    </article>
+
+    <article class="case reveal">
+      <div class="case-frame case-frame--sku">
+        <div class="window-bar">
+          <div class="dots"><span></span><span></span><span></span></div>
+          <div class="url">app.skumanager.com — Catalog</div>
+        </div>
+        <div class="dash">
+          <div class="dash-head">
+            12,408 SKUs <small>Updated 3 min ago</small>
+          </div>
+          <div class="dash-table">
+            <div class="th">SKU</div><div class="th">Variant</div><div class="th">Stock</div><div class="th">Status</div>
+            <div class="td">NSF-1184-BLK</div><div class="td">Standard</div><div class="td">412</div><div class="td"><span class="pill pill--live">Live</span></div>
+            <div class="td">NSF-2210-GRY</div><div class="td">Premium</div><div class="td">38</div><div class="td"><span class="pill pill--live">Live</span></div>
+            <div class="td">NSF-9001-EVG</div><div class="td">Limited</div><div class="td">0</div><div class="td"><span class="pill pill--draft">Draft</span></div>
+            <div class="td">NSF-4470-RED</div><div class="td">Standard</div><div class="td">1,204</div><div class="td"><span class="pill pill--live">Live</span></div>
+            <div class="td">NSF-7732-CRM</div><div class="td">Bundle</div><div class="td">29</div><div class="td"><span class="pill pill--live">Live</span></div>
+          </div>
+        </div>
+      </div>
+      <div class="case-meta">
+        <span class="case-status"><span class="dot"></span> Live</span>
+        <div></div>
+        <h3 class="case-name" style="grid-column: 1 / -1;">SKU Manager</h3>
+        <p class="case-desc" style="grid-column: 1 / -1;">Operations tooling for merchandising teams running complex catalogues at scale. Built for the businesses where product data is the business.</p>
+        <a class="case-link" href="https://skumanager.com" target="_blank" rel="noopener" style="grid-column: 1 / -1;">
+          Visit skumanager.com
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </a>
+      </div>
+    </article>
+  </div>
+</section>
+
+<!-- PROCESS ---------------------------------------------------------------- -->
+<section class="process" id="process">
+  <div class="process-inner">
+    <div class="section-head process-head">
+      <span class="label">§ How we work</span>
+      <h2>Four weeks, <em>not</em> four months.</h2>
+      <p class="aside">Most engagements run 4–12 weeks. We rebuild this timeline together at the start.</p>
+    </div>
+    <div class="timeline">
+      <article class="step reveal">
+        <span class="step-num">Week 01</span>
+        <p>We map the system, the team, and the constraints. Output: one page that everyone signs.</p>
+        <h4>Frame the <em>real</em> problem.</h4>
+      </article>
+      <article class="step reveal">
+        <span class="step-num">Week 02</span>
+        <p>First commit on day two. By Friday it's in front of users — even if rough.</p>
+        <h4>Ship something that runs.</h4>
+      </article>
+      <article class="step reveal">
+        <span class="step-num">Week 03</span>
+        <p>Measure, cut, sharpen. AI handles the boilerplate so humans do the judgement work.</p>
+        <h4>Refine in <em>public</em>.</h4>
+      </article>
+      <article class="step reveal">
+        <span class="step-num">Week 04+</span>
+        <p>Permanent ownership transfer or a monthly retainer — your call, every quarter.</p>
+        <h4>Hand over, or stay close.</h4>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- PULL QUOTE / TESTIMONIAL ---------------------------------------------- -->
+<section class="pullquote" id="about">
+  <blockquote class="reveal">
+    "NITSOF cut our expected delivery timeline in <em>half</em>. The AI-first approach isn't a pitch — it's just how they actually work, every day, every meeting."
+  </blockquote>
+  <div class="attribution reveal">
+    <div class="name">James Harlow</div>
+    <div class="role">CTO · Apex Logistics Group</div>
+    <div class="others">
+      <div class="o"><span>Priya Mehta</span><span>Stackborn</span></div>
+      <div class="o"><span>Daniel Osei</span><span>Mercia Health</span></div>
+      <div class="o" style="border: 0;"><span>Maya Lindgren</span><span>Nordpath Retail</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA BLOCK -------------------------------------------------------------- -->
+<section class="cta" id="contact">
+  <div class="cta-card">
+    <div class="reveal">
+      <h2>Have something you'd ship if it were <em>easy</em>?</h2>
+      <p class="lead">Tell us what you're trying to build. We respond within one working day with either a plan or an honest reason why we're not the right studio for it.</p>
+    </div>
+    <div class="cta-aside reveal">
+      <div class="cta-email">
+        Direct line
+        <a href="mailto:hello@nitsof.com">hello@nitsof.com</a>
+      </div>
+      <a class="cta-btn" href="mailto:hello@nitsof.com">
+        Start a brief
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER ----------------------------------------------------------------- -->
+<footer class="footer">
+  <span>© 2026 NITSOF · All rights reserved</span>
+  <span><a href="/privacy">Privacy</a> · <a href="mailto:hello@nitsof.com">hello@nitsof.com</a></span>
+  <span>Hybrid preview · v0.1</span>
+</footer>
+
+<script>
+  const params = new URLSearchParams(location.search);
+  const STATIC = params.has("static");
+  const els = document.querySelectorAll(".reveal");
+
+  if (STATIC) {
+    els.forEach(el => el.classList.add("in"));
+    document.body.classList.add("past-hero");
+  } else {
+    // Reveal animation
+    const io = new IntersectionObserver((entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          e.target.classList.add("in");
+          io.unobserve(e.target);
+        }
+      }
+    }, { rootMargin: "-8% 0px -8% 0px", threshold: 0.05 });
+    els.forEach(el => io.observe(el));
+
+    // Nav + grain transition after hero
+    const bridge = document.querySelector(".bridge");
+    const bridgeObs = new IntersectionObserver((entries) => {
+      for (const e of entries) {
+        document.body.classList.toggle("past-hero", !e.isIntersecting || e.boundingClientRect.top < 0);
+      }
+    }, { threshold: 0 });
+    if (bridge) bridgeObs.observe(bridge);
+  }
+</script>
+</body>
+</html>

--- a/public/refresh-preview/index.html
+++ b/public/refresh-preview/index.html
@@ -1,0 +1,1296 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>NITSOF — Brand Refresh Preview</title>
+<meta name="description" content="A directional preview of a refreshed NITSOF identity: simplicity, confidence, future." />
+
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,200..900,0..100,0..1&family=Manrope:wght@300..700&family=JetBrains+Mono:wght@400;500&display=swap"
+  rel="stylesheet"
+/>
+
+<style>
+/* =========================================================================
+   NITSOF — refresh preview
+   A single-file directional concept. Not production code.
+   ========================================================================= */
+
+:root {
+  --cream:        #F4EFE6;
+  --cream-deep:   #ECE6D7;
+  --ink:          #0A0908;
+  --ink-soft:     #1A1816;
+  --ink-mute:     #6C6660;
+  --rule:         #1A18161A;
+  --cobalt:       #1740FF;
+  --cobalt-deep:  #0A1E8A;
+  --signal:       #CAFF39;
+  --warn:         #FF5A1F;
+
+  --pad: clamp(1.25rem, 4vw, 3rem);
+  --max: 1440px;
+
+  --font-display: "Fraunces", "Times New Roman", serif;
+  --font-body:    "Manrope", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+body {
+  font-family: var(--font-body);
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.55;
+  background: var(--cream);
+  color: var(--ink);
+  overflow-x: hidden;
+  font-feature-settings: "ss01", "cv02", "cv11";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Subtle warm grain that ties the cream canvas together */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1000;
+  opacity: .35;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.04  0 0 0 0 0.035  0 0 0 0 0.03  0 0 0 0.42 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+}
+
+a { color: inherit; text-decoration: none; }
+button { font: inherit; cursor: pointer; }
+
+::selection { background: var(--cobalt); color: var(--cream); }
+
+/* -------------------------------------------------------------------------
+   TICKER
+   ------------------------------------------------------------------------- */
+.ticker {
+  position: relative;
+  z-index: 30;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  overflow: hidden;
+  background: var(--cream);
+}
+.ticker-track {
+  display: flex;
+  gap: 3rem;
+  white-space: nowrap;
+  padding: 0.65rem 0;
+  width: max-content;
+  animation: scroll 60s linear infinite;
+}
+.ticker-item { display: inline-flex; align-items: center; gap: .6rem; }
+.ticker-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--ink); opacity: .25;
+}
+.ticker-item--live .ticker-dot {
+  background: var(--signal);
+  opacity: 1;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--signal) 35%, transparent);
+  animation: pulse 1.8s ease-in-out infinite;
+}
+.ticker-item strong { color: var(--ink); font-weight: 500; }
+@keyframes scroll { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 4px color-mix(in srgb, var(--signal) 35%, transparent); }
+  50%      { box-shadow: 0 0 0 9px color-mix(in srgb, var(--signal) 0%, transparent); }
+}
+
+/* -------------------------------------------------------------------------
+   HEADER
+   ------------------------------------------------------------------------- */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 25;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 2rem;
+  padding: 1.1rem var(--pad);
+  background: color-mix(in srgb, var(--cream) 85%, transparent);
+  backdrop-filter: saturate(180%) blur(10px);
+  -webkit-backdrop-filter: saturate(180%) blur(10px);
+  border-bottom: 1px solid var(--rule);
+}
+.wordmark {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-variation-settings: "opsz" 144, "SOFT" 0, "WONK" 0;
+  font-size: 1.25rem;
+  letter-spacing: -0.02em;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+.wordmark .dot {
+  width: 8px; height: 8px;
+  background: var(--cobalt);
+  border-radius: 1px;
+  transform: translateY(-2px);
+}
+.nav-links {
+  display: flex;
+  justify-self: center;
+  gap: 2.25rem;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.nav-links a {
+  position: relative;
+  padding: 0.25rem 0;
+  color: var(--ink);
+  opacity: .7;
+  transition: opacity .2s ease;
+}
+.nav-links a:hover { opacity: 1; }
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -2px;
+  height: 1px;
+  background: var(--cobalt);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform .35s cubic-bezier(.2,.7,.2,1);
+}
+.nav-links a:hover::after { transform: scaleX(1); }
+@media (max-width: 760px) { .nav-links { display: none; } }
+
+.nav-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: .6rem;
+  padding: 0.55rem 1rem;
+  background: var(--ink);
+  color: var(--cream);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform .25s ease, background .25s ease;
+}
+.nav-cta:hover { background: var(--cobalt); transform: translateY(-1px); }
+.nav-cta .arrow { transition: transform .25s ease; }
+.nav-cta:hover .arrow { transform: translateX(3px); }
+
+/* -------------------------------------------------------------------------
+   HERO
+   ------------------------------------------------------------------------- */
+.hero {
+  position: relative;
+  padding: clamp(3rem, 8vw, 7rem) var(--pad) clamp(3rem, 6vw, 5rem);
+  max-width: var(--max);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+}
+@media (min-width: 1024px) {
+  .hero { grid-template-columns: minmax(0, 1fr) 22rem; align-items: end; gap: 5rem; }
+}
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-mute);
+  display: inline-flex;
+  align-items: center;
+  gap: .8rem;
+  margin-bottom: 1.75rem;
+}
+.eyebrow::before {
+  content: "";
+  width: 28px; height: 1px;
+  background: var(--ink);
+}
+
+.hero h1 {
+  font-family: var(--font-display);
+  font-weight: 350;
+  font-variation-settings: "opsz" 144, "SOFT" 0, "WONK" 1;
+  font-size: clamp(2.8rem, 8.4vw, 8.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  color: var(--ink);
+  text-wrap: balance;
+}
+.hero h1 em {
+  font-style: italic;
+  font-weight: 300;
+  font-variation-settings: "opsz" 144, "SOFT" 100, "WONK" 1;
+  color: var(--cobalt);
+}
+.hero h1 .underline {
+  display: inline-block;
+  position: relative;
+}
+.hero h1 .underline::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0;
+  bottom: 0.06em;
+  height: 0.12em;
+  background: var(--signal);
+  z-index: -1;
+  transform-origin: left;
+  animation: stroke 1.4s cubic-bezier(.2,.7,.2,1) 0.7s both;
+}
+@keyframes stroke { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+
+.hero-meta {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.75rem;
+  align-self: end;
+  padding-bottom: .4rem;
+}
+.meta-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--rule);
+}
+.meta-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.meta-value {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+}
+.meta-value.serif-bigger {
+  font-size: 1.25rem;
+  font-variation-settings: "opsz" 30;
+}
+
+.hero-actions {
+  margin-top: 2.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 1.05rem 1.6rem;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform .3s cubic-bezier(.2,.7,.2,1), background .25s ease, color .25s ease;
+}
+.btn--primary {
+  background: var(--ink);
+  color: var(--cream);
+}
+.btn--primary:hover { background: var(--cobalt); transform: translateY(-2px); }
+.btn--ghost {
+  border: 1px solid var(--ink);
+  color: var(--ink);
+}
+.btn--ghost:hover { background: var(--ink); color: var(--cream); }
+.btn .ico {
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  background: currentColor;
+  display: inline-flex; align-items: center; justify-content: center;
+  position: relative;
+}
+.btn .ico::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23F4EFE6' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'><path d='M5 12h14M13 5l7 7-7 7'/></svg>") center/12px no-repeat;
+}
+.btn--ghost .ico::after {
+  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23F4EFE6' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'><path d='M5 12h14M13 5l7 7-7 7'/></svg>") center/12px no-repeat;
+}
+
+/* -------------------------------------------------------------------------
+   MANIFESTO STRIP
+   ------------------------------------------------------------------------- */
+.manifesto {
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  background: var(--cream-deep);
+  overflow: hidden;
+}
+.manifesto-inner {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 3.5rem) var(--pad);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+}
+@media (min-width: 900px) {
+  .manifesto-inner { grid-template-columns: repeat(3, 1fr); gap: 3rem; }
+}
+.principle {
+  position: relative;
+  padding-top: 1.4rem;
+  border-top: 1px solid var(--ink);
+}
+.principle-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--ink-mute);
+  position: absolute;
+  top: 1.4rem; right: 0;
+}
+.principle h3 {
+  font-family: var(--font-display);
+  font-weight: 350;
+  font-variation-settings: "opsz" 144, "WONK" 1;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  line-height: 1;
+  letter-spacing: -0.025em;
+  margin-bottom: 1rem;
+}
+.principle h3 em { font-style: italic; color: var(--cobalt); font-weight: 300; }
+.principle p {
+  font-size: 0.95rem;
+  color: var(--ink-soft);
+  max-width: 32ch;
+}
+
+/* -------------------------------------------------------------------------
+   CAPABILITIES
+   ------------------------------------------------------------------------- */
+.section {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 9vw, 7rem) var(--pad);
+}
+
+.section-head {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  margin-bottom: clamp(3rem, 6vw, 5rem);
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  align-items: end;
+}
+@media (min-width: 900px) {
+  .section-head { grid-template-columns: auto 1fr auto; gap: 3rem; }
+}
+.section-head .label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-mute);
+}
+.section-head h2 {
+  font-family: var(--font-display);
+  font-weight: 350;
+  font-variation-settings: "opsz" 144;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  letter-spacing: -0.03em;
+  line-height: 1;
+  text-wrap: balance;
+}
+.section-head h2 em { font-style: italic; color: var(--cobalt); font-weight: 300; }
+.section-head .aside {
+  font-size: 0.9rem;
+  max-width: 26ch;
+  color: var(--ink-mute);
+  align-self: end;
+}
+
+.capabilities {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+}
+@media (min-width: 720px) { .capabilities { grid-template-columns: 1fr 1fr; } }
+@media (min-width: 1100px) { .capabilities { grid-template-columns: repeat(4, 1fr); } }
+
+.cap {
+  background: var(--cream);
+  padding: 2rem 1.8rem 2.5rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  min-height: 320px;
+  transition: background .35s ease, color .35s ease;
+}
+.cap:hover { background: var(--ink); color: var(--cream); }
+.cap:hover .cap-num,
+.cap:hover .cap-desc { color: color-mix(in srgb, var(--cream) 75%, transparent); }
+.cap:hover .cap-arrow { transform: translate(6px, -6px); color: var(--signal); }
+
+.cap-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  color: var(--ink-mute);
+  transition: color .35s ease;
+}
+.cap h3 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-variation-settings: "opsz" 144;
+  font-size: 1.55rem;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin-top: auto;
+}
+.cap-desc {
+  font-size: 0.92rem;
+  color: var(--ink-soft);
+  transition: color .35s ease;
+  max-width: 30ch;
+}
+.cap-arrow {
+  position: absolute;
+  top: 1.8rem; right: 1.8rem;
+  width: 20px; height: 20px;
+  color: var(--ink-mute);
+  transition: transform .35s cubic-bezier(.2,.7,.2,1), color .35s ease;
+}
+
+/* -------------------------------------------------------------------------
+   SELECTED WORK
+   ------------------------------------------------------------------------- */
+.work {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+}
+@media (min-width: 960px) { .work { grid-template-columns: 1fr 1fr; gap: 2rem; } }
+
+.case {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  group: case;
+}
+.case-frame {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--ink);
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  border: 1px solid var(--rule);
+  transition: transform .5s cubic-bezier(.2,.7,.2,1);
+}
+.case:hover .case-frame { transform: translateY(-6px); }
+
+.case-frame--carrier { background: linear-gradient(155deg, #0b153f 0%, #0a0908 60%); }
+.case-frame--sku     { background: linear-gradient(155deg, #1a1816 0%, #0a0908 70%); }
+
+.window-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: color-mix(in srgb, var(--cream) 50%, transparent);
+}
+.window-bar .dots {
+  display: flex; gap: 5px;
+}
+.window-bar .dots span {
+  width: 9px; height: 9px; border-radius: 50%;
+  background: color-mix(in srgb, var(--cream) 18%, transparent);
+}
+.window-bar .url {
+  margin-left: 0.9rem;
+  padding: 0.2rem 0.65rem;
+  background: color-mix(in srgb, var(--cream) 8%, transparent);
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+}
+
+/* Carrier Rates mock checkout */
+.checkout {
+  flex: 1;
+  background: var(--cream);
+  border-radius: 4px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  color: var(--ink);
+}
+.checkout-title {
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.checkout-title small {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.rate {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.55rem 0.7rem;
+  background: var(--cream-deep);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.rate--active {
+  background: var(--ink);
+  color: var(--cream);
+  outline: 2px solid var(--cobalt);
+  outline-offset: -2px;
+}
+.rate strong {
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+.rate-eta {
+  color: var(--ink-mute);
+  font-size: 9px;
+}
+.rate--active .rate-eta { color: color-mix(in srgb, var(--cream) 60%, transparent); }
+.rate-price {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+/* SKU manager mock dashboard */
+.dash {
+  flex: 1;
+  background: var(--cream);
+  border-radius: 4px;
+  padding: 0.8rem;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 0.55rem;
+  color: var(--ink);
+}
+.dash-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+.dash-head small {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.dash-table {
+  display: grid;
+  grid-template-columns: 1fr 0.6fr 0.5fr 0.5fr;
+  gap: 0.3rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  align-content: start;
+}
+.dash-table .th {
+  font-family: var(--font-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  font-size: 8.5px;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--rule);
+}
+.dash-table .td {
+  padding: 0.32rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+.dash-table .pill {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 8px;
+  letter-spacing: 0.04em;
+}
+.pill--live { background: color-mix(in srgb, var(--signal) 40%, var(--cream)); color: var(--ink); }
+.pill--draft { background: var(--cream-deep); color: var(--ink-mute); }
+
+.case-meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1rem;
+  align-items: baseline;
+}
+.case-status {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+}
+.case-status .dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--signal);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--signal) 35%, transparent);
+}
+.case-name {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-variation-settings: "opsz" 144;
+  font-size: 1.65rem;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.case-desc { color: var(--ink-soft); font-size: 0.95rem; max-width: 50ch; }
+.case-link {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: .55rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--ink);
+  width: fit-content;
+  transition: gap .25s ease, color .25s ease, border-color .25s ease;
+}
+.case-link:hover { gap: .85rem; color: var(--cobalt); border-color: var(--cobalt); }
+
+/* -------------------------------------------------------------------------
+   PROCESS / TIMELINE
+   ------------------------------------------------------------------------- */
+.process {
+  background: var(--ink);
+  color: var(--cream);
+  position: relative;
+  overflow: hidden;
+}
+.process::after {
+  content: "";
+  position: absolute;
+  right: -10%;
+  top: -20%;
+  width: 50vw; height: 50vw;
+  border-radius: 50%;
+  background: radial-gradient(circle, color-mix(in srgb, var(--cobalt) 35%, transparent), transparent 65%);
+  pointer-events: none;
+}
+.process-inner {
+  position: relative; z-index: 2;
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 9vw, 7rem) var(--pad);
+}
+.process-head h2 { color: var(--cream); }
+.process-head .label { color: color-mix(in srgb, var(--cream) 55%, transparent); }
+.process-head .aside { color: color-mix(in srgb, var(--cream) 60%, transparent); }
+.process-head { border-color: color-mix(in srgb, var(--cream) 15%, transparent); }
+
+.timeline {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: color-mix(in srgb, var(--cream) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--cream) 12%, transparent);
+}
+@media (min-width: 820px) { .timeline { grid-template-columns: repeat(4, 1fr); } }
+
+.step {
+  background: var(--ink);
+  padding: 2rem 1.8rem 2.4rem;
+  display: flex; flex-direction: column; gap: 0.8rem;
+  position: relative;
+  min-height: 240px;
+}
+.step-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: color-mix(in srgb, var(--cream) 45%, transparent);
+}
+.step h4 {
+  font-family: var(--font-display);
+  font-weight: 350;
+  font-variation-settings: "opsz" 100;
+  font-size: 1.55rem;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  color: var(--cream);
+}
+.step h4 em { color: var(--signal); font-style: italic; font-weight: 300; }
+.step p {
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--cream) 65%, transparent);
+  max-width: 30ch;
+  margin-top: auto;
+}
+
+/* -------------------------------------------------------------------------
+   PULL QUOTE
+   ------------------------------------------------------------------------- */
+.pullquote {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 10vw, 8rem) var(--pad);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+}
+@media (min-width: 900px) {
+  .pullquote { grid-template-columns: minmax(0,1fr) 18rem; gap: 4rem; align-items: end; }
+}
+.pullquote blockquote {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-variation-settings: "opsz" 144, "SOFT" 50, "WONK" 1;
+  font-size: clamp(1.8rem, 4.5vw, 3.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+}
+.pullquote blockquote em {
+  font-style: italic;
+  color: var(--cobalt);
+  font-weight: 300;
+}
+.attribution {
+  border-top: 1px solid var(--ink);
+  padding-top: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.attribution .name {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+}
+.attribution .role {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.attribution .others {
+  margin-top: 0.9rem;
+  display: flex; flex-direction: column; gap: 0.3rem;
+  font-size: 0.85rem;
+  color: var(--ink-soft);
+}
+.attribution .others .o {
+  display: flex; justify-content: space-between; gap: 1rem;
+  border-bottom: 1px dashed var(--rule);
+  padding-bottom: 0.3rem;
+}
+.attribution .others .o span:last-child {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
+/* -------------------------------------------------------------------------
+   CTA BLOCK
+   ------------------------------------------------------------------------- */
+.cta {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 0 var(--pad) clamp(4rem, 8vw, 6rem);
+}
+.cta-card {
+  position: relative;
+  overflow: hidden;
+  background: var(--ink);
+  color: var(--cream);
+  border-radius: 8px;
+  padding: clamp(2.5rem, 7vw, 6rem) clamp(2rem, 6vw, 5rem);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+}
+@media (min-width: 900px) { .cta-card { grid-template-columns: 1.4fr 1fr; gap: 4rem; align-items: end; } }
+
+.cta-card::before {
+  content: "";
+  position: absolute;
+  left: -10%; bottom: -60%;
+  width: 60vw; height: 60vw;
+  background: radial-gradient(circle, color-mix(in srgb, var(--cobalt) 70%, transparent), transparent 60%);
+  pointer-events: none;
+  filter: blur(20px);
+}
+.cta-card > * { position: relative; z-index: 2; }
+
+.cta h2 {
+  font-family: var(--font-display);
+  font-weight: 350;
+  font-variation-settings: "opsz" 144, "WONK" 1;
+  font-size: clamp(2.2rem, 6vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  text-wrap: balance;
+}
+.cta h2 em { font-style: italic; color: var(--signal); font-weight: 300; }
+.cta .lead { color: color-mix(in srgb, var(--cream) 75%, transparent); max-width: 36ch; margin-top: 1.5rem; }
+
+.cta-aside {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  align-self: end;
+}
+.cta-email {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--cream) 55%, transparent);
+}
+.cta-email a {
+  display: block;
+  font-family: var(--font-display);
+  text-transform: none;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.2rem, 2.2vw, 1.6rem);
+  color: var(--cream);
+  font-weight: 400;
+  margin-top: 0.4rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--cream) 30%, transparent);
+  padding-bottom: 0.7rem;
+  transition: color .25s ease, border-color .25s ease;
+}
+.cta-email a:hover { color: var(--signal); border-color: var(--signal); }
+
+.cta-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.4rem;
+  background: var(--cream);
+  color: var(--ink);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform .25s ease, background .25s ease;
+}
+.cta-btn:hover { background: var(--signal); transform: translateY(-2px); }
+.cta-btn svg { margin-left: 1.2rem; }
+
+/* -------------------------------------------------------------------------
+   FOOTER
+   ------------------------------------------------------------------------- */
+.footer {
+  border-top: 1px solid var(--rule);
+  padding: 2.5rem var(--pad);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  max-width: var(--max);
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+}
+.footer a:hover { color: var(--ink); }
+
+/* -------------------------------------------------------------------------
+   REVEAL ANIMATIONS
+   ------------------------------------------------------------------------- */
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity .9s cubic-bezier(.2,.7,.2,1), transform .9s cubic-bezier(.2,.7,.2,1);
+}
+.reveal.in {
+  opacity: 1;
+  transform: translateY(0);
+}
+.reveal:nth-child(2) { transition-delay: 0.08s; }
+.reveal:nth-child(3) { transition-delay: 0.16s; }
+.reveal:nth-child(4) { transition-delay: 0.24s; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
+  .reveal { opacity: 1; transform: none; }
+}
+</style>
+</head>
+<body>
+
+<!-- TICKER ----------------------------------------------------------------- -->
+<div class="ticker" aria-hidden="true">
+  <div class="ticker-track">
+    <span class="ticker-item ticker-item--live"><span class="ticker-dot"></span> <strong>Now shipping</strong> · Carrier Rates v2.1 — live in 240+ stores</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> AI-augmented delivery · est. 2024</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Currently accepting Q3 engagements</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Software ↔ thought · velocity 4.2×</span>
+    <span class="ticker-item ticker-item--live"><span class="ticker-dot"></span> <strong>Now shipping</strong> · Carrier Rates v2.1 — live in 240+ stores</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> AI-augmented delivery · est. 2024</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Currently accepting Q3 engagements</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Software ↔ thought · velocity 4.2×</span>
+  </div>
+</div>
+
+<!-- HEADER ----------------------------------------------------------------- -->
+<header class="nav">
+  <a class="wordmark" href="#">
+    NITSOF<span class="dot" aria-hidden="true"></span>
+  </a>
+  <nav class="nav-links">
+    <a href="#work">Work</a>
+    <a href="#capabilities">Capabilities</a>
+    <a href="#process">Process</a>
+    <a href="#about">Studio</a>
+  </nav>
+  <a class="nav-cta" href="#contact">
+    Start a project
+    <svg class="arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+  </a>
+</header>
+
+<!-- HERO ------------------------------------------------------------------- -->
+<section class="hero">
+  <div class="reveal">
+    <p class="eyebrow">An AI-native software studio</p>
+    <h1>
+      Software,<br>
+      shipped at the speed<br>
+      of <em>thought</em>.
+    </h1>
+
+    <div class="hero-actions">
+      <a class="btn btn--primary" href="#work">
+        See selected work
+        <span class="ico" aria-hidden="true"></span>
+      </a>
+      <a class="btn btn--ghost" href="#contact">
+        Begin a project
+      </a>
+    </div>
+  </div>
+
+  <aside class="hero-meta reveal">
+    <div class="meta-row">
+      <div>
+        <div class="meta-label">Studio</div>
+        <div class="meta-value serif-bigger">NITSOF</div>
+      </div>
+      <div>
+        <div class="meta-label">Est.</div>
+        <div class="meta-value">2024</div>
+      </div>
+    </div>
+    <div class="meta-row">
+      <div>
+        <div class="meta-label">Discipline</div>
+        <div class="meta-value">Software, AI-led</div>
+      </div>
+      <div>
+        <div class="meta-label">Index</div>
+        <div class="meta-value">№ 011 / 2026</div>
+      </div>
+    </div>
+    <div class="meta-row" style="border: 0; padding-bottom: 0;">
+      <div>
+        <div class="meta-label">Capacity</div>
+        <div class="meta-value" style="display:inline-flex;align-items:center;gap:.5rem;">
+          <span style="width:7px;height:7px;border-radius:50%;background:var(--signal);box-shadow:0 0 0 3px color-mix(in srgb, var(--signal) 35%, transparent);"></span>
+          Open · Q3 2026
+        </div>
+      </div>
+      <div>
+        <div class="meta-label">From</div>
+        <div class="meta-value">Remote · UK / EU</div>
+      </div>
+    </div>
+  </aside>
+</section>
+
+<!-- MANIFESTO STRIP -------------------------------------------------------- -->
+<section class="manifesto">
+  <div class="manifesto-inner">
+    <div class="principle reveal">
+      <span class="principle-num">01 — Principle</span>
+      <h3>Simplicity is <em>the</em> feature.</h3>
+      <p>We strip out everything that doesn't earn its place. Fewer dependencies, fewer screens, fewer meetings. The shortest path from problem to production.</p>
+    </div>
+    <div class="principle reveal">
+      <span class="principle-num">02 — Principle</span>
+      <h3>Confidence in <em>craft</em>.</h3>
+      <p>We don't ship demos. We ship software our clients depend on to run their business — measured in uptime, revenue, and the quality of a sleepless night avoided.</p>
+    </div>
+    <div class="principle reveal">
+      <span class="principle-num">03 — Principle</span>
+      <h3>Building the <em>future</em>, now.</h3>
+      <p>AI sits inside our delivery loop, not as a feature on a slide. The pace this enables is the only thing that lets a four-person team out-ship a fifty-person one.</p>
+    </div>
+  </div>
+</section>
+
+<!-- CAPABILITIES ----------------------------------------------------------- -->
+<section class="section" id="capabilities">
+  <div class="section-head">
+    <span class="label">§ Capabilities</span>
+    <h2>Four disciplines, <em>one</em> studio.</h2>
+    <p class="aside">Each engagement is led by a senior engineer who stays through delivery. No handoffs, no juniors learning on your time.</p>
+  </div>
+
+  <div class="capabilities">
+    <article class="cap reveal">
+      <span class="cap-num">01 / Strategy</span>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 17L17 7M9 7h8v8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <h3>Product <em>archaeology</em>.</h3>
+      <p class="cap-desc">We map what's actually there before adding anything new — most teams already have 70% of what they need, just badly arranged.</p>
+    </article>
+    <article class="cap reveal">
+      <span class="cap-num">02 / Build</span>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 17L17 7M9 7h8v8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <h3>AI-augmented engineering.</h3>
+      <p class="cap-desc">Senior engineers paired with AI throughout — design, code, review, QA. Same craft, 3–5× the throughput.</p>
+    </article>
+    <article class="cap reveal">
+      <span class="cap-num">03 / Ship</span>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 17L17 7M9 7h8v8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <h3>Production from <em>day one</em>.</h3>
+      <p class="cap-desc">Every commit deploys. No staging-forever environments — real users, real load, measured from the first week.</p>
+    </article>
+    <article class="cap reveal">
+      <span class="cap-num">04 / Iterate</span>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 17L17 7M9 7h8v8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <h3>Stay in the loop.</h3>
+      <p class="cap-desc">We don't disappear at launch. Monthly cadence, real metrics, the kind of partner you keep on speed dial.</p>
+    </article>
+  </div>
+</section>
+
+<!-- SELECTED WORK ---------------------------------------------------------- -->
+<section class="section" id="work" style="padding-top: 0;">
+  <div class="section-head">
+    <span class="label">§ Selected work</span>
+    <h2>Built in <em>production</em>. Not in a deck.</h2>
+    <p class="aside">A small selection of the studio's recent work. Full case studies on request.</p>
+  </div>
+
+  <div class="work">
+
+    <article class="case reveal">
+      <div class="case-frame case-frame--carrier">
+        <div class="window-bar">
+          <div class="dots"><span></span><span></span><span></span></div>
+          <div class="url">checkout.acme-store.com</div>
+        </div>
+        <div class="checkout">
+          <div class="checkout-title">Shipping <small>Step 2 of 3</small></div>
+          <div class="rate">
+            <div><strong>Royal Mail · 48 hour tracked</strong><div class="rate-eta">Arrives Thu 21 May</div></div>
+            <div class="rate-price">£3.49</div>
+          </div>
+          <div class="rate rate--active">
+            <div><strong>DPD Next Day · before 12:00</strong><div class="rate-eta">Arrives Wed 20 May</div></div>
+            <div class="rate-price">£6.20</div>
+          </div>
+          <div class="rate">
+            <div><strong>Evri Standard · 3–5 day</strong><div class="rate-eta">Arrives Mon 25 May</div></div>
+            <div class="rate-price">£2.10</div>
+          </div>
+          <div class="rate">
+            <div><strong>UPS International Saver</strong><div class="rate-eta">Arrives Fri 22 May</div></div>
+            <div class="rate-price">£14.85</div>
+          </div>
+        </div>
+      </div>
+      <div class="case-meta">
+        <span class="case-status"><span class="dot"></span> Live</span>
+        <div></div>
+        <h3 class="case-name" style="grid-column: 1 / -1;">Carrier Rates</h3>
+        <p class="case-desc" style="grid-column: 1 / -1;">A Shopify integration that surfaces live carrier pricing directly at checkout — the moment shoppers decide to buy or bail.</p>
+        <a class="case-link" href="#" style="grid-column: 1 / -1;">
+          Read case
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </a>
+      </div>
+    </article>
+
+    <article class="case reveal">
+      <div class="case-frame case-frame--sku">
+        <div class="window-bar">
+          <div class="dots"><span></span><span></span><span></span></div>
+          <div class="url">app.skumanager.com — Catalog</div>
+        </div>
+        <div class="dash">
+          <div class="dash-head">
+            12,408 SKUs <small>Updated 3 min ago</small>
+          </div>
+          <div class="dash-table">
+            <div class="th">SKU</div><div class="th">Variant</div><div class="th">Stock</div><div class="th">Status</div>
+            <div class="td">NSF-1184-BLK</div><div class="td">Standard</div><div class="td">412</div><div class="td"><span class="pill pill--live">Live</span></div>
+            <div class="td">NSF-2210-GRY</div><div class="td">Premium</div><div class="td">38</div><div class="td"><span class="pill pill--live">Live</span></div>
+            <div class="td">NSF-9001-EVG</div><div class="td">Limited</div><div class="td">0</div><div class="td"><span class="pill pill--draft">Draft</span></div>
+            <div class="td">NSF-4470-RED</div><div class="td">Standard</div><div class="td">1,204</div><div class="td"><span class="pill pill--live">Live</span></div>
+            <div class="td">NSF-7732-CRM</div><div class="td">Bundle</div><div class="td">29</div><div class="td"><span class="pill pill--live">Live</span></div>
+          </div>
+        </div>
+      </div>
+      <div class="case-meta">
+        <span class="case-status"><span class="dot"></span> Live</span>
+        <div></div>
+        <h3 class="case-name" style="grid-column: 1 / -1;">SKU Manager</h3>
+        <p class="case-desc" style="grid-column: 1 / -1;">Operations tooling for merchandising teams running complex catalogues at scale. Built for the businesses where product data is the business.</p>
+        <a class="case-link" href="#" style="grid-column: 1 / -1;">
+          Visit skumanager.com
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </a>
+      </div>
+    </article>
+
+  </div>
+</section>
+
+<!-- PROCESS ---------------------------------------------------------------- -->
+<section class="process" id="process">
+  <div class="process-inner">
+    <div class="section-head process-head">
+      <span class="label">§ How we work</span>
+      <h2>Four weeks, <em>not</em> four months.</h2>
+      <p class="aside">Most engagements run 4–12 weeks. We rebuild this timeline together at the start.</p>
+    </div>
+
+    <div class="timeline">
+      <article class="step reveal">
+        <span class="step-num">Week 01</span>
+        <p>We map the system, the team, and the constraints. Output: one page that everyone signs.</p>
+        <h4>Frame the <em>real</em> problem.</h4>
+      </article>
+      <article class="step reveal">
+        <span class="step-num">Week 02</span>
+        <p>First commit on day two. By Friday it's in front of users — even if rough.</p>
+        <h4>Ship something that runs.</h4>
+      </article>
+      <article class="step reveal">
+        <span class="step-num">Week 03</span>
+        <p>Measure, cut, sharpen. AI handles the boilerplate so humans do the judgement work.</p>
+        <h4>Refine in <em>public</em>.</h4>
+      </article>
+      <article class="step reveal">
+        <span class="step-num">Week 04+</span>
+        <p>Permanent ownership transfer or a monthly retainer — your call, every quarter.</p>
+        <h4>Hand over, or stay close.</h4>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- PULL QUOTE / TESTIMONIAL ---------------------------------------------- -->
+<section class="pullquote" id="about">
+  <blockquote class="reveal">
+    “NITSOF cut our expected delivery timeline in <em>half</em>. The AI-first approach isn't a pitch — it's just how they actually work, every day, every meeting.”
+  </blockquote>
+  <div class="attribution reveal">
+    <div class="name">James Harlow</div>
+    <div class="role">CTO · Apex Logistics Group</div>
+    <div class="others">
+      <div class="o"><span>Priya Mehta</span><span>Stackborn</span></div>
+      <div class="o"><span>Daniel Osei</span><span>Mercia Health</span></div>
+      <div class="o" style="border: 0;"><span>Maya Lindgren</span><span>Nordpath Retail</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA BLOCK -------------------------------------------------------------- -->
+<section class="cta" id="contact">
+  <div class="cta-card">
+    <div class="reveal">
+      <h2>Have something you'd ship if it were <em>easy</em>?</h2>
+      <p class="lead">Tell us what you're trying to build. We respond within one working day with either a plan or an honest reason why we're not the right studio for it.</p>
+    </div>
+    <div class="cta-aside reveal">
+      <div class="cta-email">
+        Direct line
+        <a href="mailto:hello@nitsof.com">hello@nitsof.com</a>
+      </div>
+      <a class="cta-btn" href="mailto:hello@nitsof.com">
+        Start a brief
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER ----------------------------------------------------------------- -->
+<footer class="footer">
+  <span>© 2026 NITSOF · All rights reserved</span>
+  <span><a href="/privacy">Privacy</a> · <a href="mailto:hello@nitsof.com">hello@nitsof.com</a></span>
+  <span>Refresh preview · v0.1</span>
+</footer>
+
+<script>
+  // Stagger reveal on scroll
+  const io = new IntersectionObserver((entries) => {
+    for (const e of entries) {
+      if (e.isIntersecting) {
+        e.target.classList.add("in");
+        io.unobserve(e.target);
+      }
+    }
+  }, { rootMargin: "-8% 0px -8% 0px", threshold: 0.05 });
+
+  document.querySelectorAll(".reveal").forEach(el => io.observe(el));
+</script>
+</body>
+</html>

--- a/public/refresh-preview/index.html
+++ b/public/refresh-preview/index.html
@@ -9,10 +9,44 @@
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link
-  href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,200..900,0..100,0..1&family=Manrope:wght@300..700&family=JetBrains+Mono:wght@400;500&display=swap"
-  rel="stylesheet"
-/>
+<link rel="preconnect" href="https://api.fontshare.com" crossorigin />
+<link rel="preconnect" href="https://cdn.fontshare.com" crossorigin />
+
+<!--
+  Typography schemes — switchable via ?type= (chip in bottom-right of the preview).
+    A (default)  · Editorial Bold     · Fraunces + Manrope        — strong character, expressive italic
+    B (editorial)· Editorial Calm     · Newsreader + Inter Tight  — softer serif, higher legibility
+    C (newsstand)· Newsstand Contrast · Instrument Serif + Inter  — high-contrast, max screen clarity
+    D (swiss)    · Swiss Modern       · General Sans + Switzer    — sans-only, tech-forward
+  All four stylesheets are loaded up front so every scheme paints with the correct
+  fonts (no FOUT). The active scheme is selected by swapping the --font-* CSS variables.
+-->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,200..900,0..100,0..1&family=Manrope:wght@300..700&family=JetBrains+Mono:wght@400;500&display=swap" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&family=Inter+Tight:ital,wght@0,300..700;1,400..600&display=swap" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@300..700&display=swap" />
+<link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=general-sans@400,500,600,700&f[]=switzer@300,400,500,600,700&display=swap" />
+
+<script>
+  // Select an active typography scheme by swapping --font-display / --font-body.
+  // Fonts themselves are already loaded via the four <link> tags above.
+  (function () {
+    var t = (new URLSearchParams(location.search).get("type") || "default").toLowerCase();
+    var vars = {
+      "default":   { d: '"Fraunces", "Times New Roman", serif',         b: '"Manrope", -apple-system, BlinkMacSystemFont, system-ui, sans-serif' },
+      "editorial": { d: '"Newsreader", "Times New Roman", serif',       b: '"Inter Tight", -apple-system, BlinkMacSystemFont, system-ui, sans-serif' },
+      "newsstand": { d: '"Instrument Serif", "Times New Roman", serif', b: '"Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif' },
+      "swiss":     { d: '"General Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif',
+                     b: '"Switzer", -apple-system, BlinkMacSystemFont, system-ui, sans-serif' }
+    };
+    var key = vars[t] ? t : "default";
+    var v = vars[key];
+    // Inline style on <html> outranks any later :root rule in a stylesheet,
+    // so the override survives even though the main <style> is parsed after this script.
+    document.documentElement.style.setProperty("--font-display", v.d);
+    document.documentElement.style.setProperty("--font-body", v.b);
+    document.documentElement.setAttribute("data-type", key);
+  })();
+</script>
 
 <style>
 /* =========================================================================
@@ -969,9 +1003,72 @@ button { font: inherit; cursor: pointer; }
   *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
   .reveal { opacity: 1; transform: none; }
 }
+
+/* -------------------------------------------------------------------------
+   TYPE SWITCHER — preview-only chrome (?type=...)
+   Docks bottom-right like a dev tool — never collides with site nav.
+   ------------------------------------------------------------------------- */
+.type-switcher {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.55rem;
+  background: rgba(244, 239, 230, 0.94);
+  backdrop-filter: blur(12px) saturate(160%);
+  -webkit-backdrop-filter: blur(12px) saturate(160%);
+  border: 1px solid rgba(10, 9, 8, 0.14);
+  border-radius: 999px;
+  box-shadow: 0 14px 40px -18px rgba(10, 9, 8, 0.45);
+  font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  max-width: calc(100vw - 2rem);
+}
+.type-switcher__label {
+  padding: 0 0.45rem 0 0.3rem;
+  border-right: 1px solid rgba(10, 9, 8, 0.14);
+  white-space: nowrap;
+}
+.type-switcher a {
+  text-decoration: none;
+  padding: 0.32rem 0.6rem;
+  border-radius: 999px;
+  color: var(--ink-mute);
+  white-space: nowrap;
+  transition: background 160ms ease, color 160ms ease;
+}
+.type-switcher a:hover { color: var(--ink); background: rgba(10, 9, 8, 0.06); }
+.type-switcher a[aria-current="true"] {
+  background: var(--ink);
+  color: var(--cream);
+}
+@media (max-width: 760px) {
+  .type-switcher {
+    left: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    font-size: 0.6rem;
+  }
+  .type-switcher__label { display: none; }
+}
 </style>
 </head>
 <body>
+
+<!-- TYPE SWITCHER (preview affordance — not part of the proposed UI) -------- -->
+<nav class="type-switcher" aria-label="Typography preview switcher">
+  <span class="type-switcher__label">Type</span>
+  <a data-type="default"   data-title="Fraunces + Manrope">A · Editorial Bold</a>
+  <a data-type="editorial" data-title="Newsreader + Inter Tight">B · Editorial Calm</a>
+  <a data-type="newsstand" data-title="Instrument Serif + Inter">C · Newsstand</a>
+  <a data-type="swiss"     data-title="General Sans + Switzer">D · Swiss Modern</a>
+</nav>
 
 <!-- TICKER ----------------------------------------------------------------- -->
 <div class="ticker" aria-hidden="true">
@@ -1158,10 +1255,10 @@ button { font: inherit; cursor: pointer; }
       <div class="case-meta">
         <span class="case-status"><span class="dot"></span> Live</span>
         <div></div>
-        <h3 class="case-name" style="grid-column: 1 / -1;">Carrier Rates</h3>
-        <p class="case-desc" style="grid-column: 1 / -1;">A Shopify integration that surfaces live carrier pricing directly at checkout — the moment shoppers decide to buy or bail.</p>
-        <a class="case-link" href="#" style="grid-column: 1 / -1;">
-          Read case
+        <h3 class="case-name" style="grid-column: 1 / -1;">Live Carrier Rates</h3>
+        <p class="case-desc" style="grid-column: 1 / -1;">A published Shopify app that surfaces real-time carrier pricing inside checkout — the moment shoppers decide to buy or bail.</p>
+        <a class="case-link" href="https://apps.shopify.com/live-carrier-rates" target="_blank" rel="noopener" style="grid-column: 1 / -1;">
+          View on the Shopify App Store
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
         </a>
       </div>
@@ -1281,7 +1378,8 @@ button { font: inherit; cursor: pointer; }
 
 <script>
   // ?static=1 — bypass reveal animations (used for screenshot capture)
-  const STATIC = new URLSearchParams(location.search).has("static");
+  const params = new URLSearchParams(location.search);
+  const STATIC = params.has("static");
   const els = document.querySelectorAll(".reveal");
 
   if (STATIC) {
@@ -1298,6 +1396,19 @@ button { font: inherit; cursor: pointer; }
     }, { rootMargin: "-8% 0px -8% 0px", threshold: 0.05 });
     els.forEach(el => io.observe(el));
   }
+
+  // Type switcher: each chip is a same-page link that swaps the ?type= param
+  // while preserving anything else (e.g. ?static=1).
+  const active = (document.documentElement.getAttribute("data-type") || "default");
+  document.querySelectorAll(".type-switcher a[data-type]").forEach(a => {
+    const t = a.getAttribute("data-type");
+    const next = new URLSearchParams(params);
+    if (t === "default") next.delete("type"); else next.set("type", t);
+    const qs = next.toString();
+    a.href = location.pathname + (qs ? "?" + qs : "") + location.hash;
+    a.title = a.getAttribute("data-title") || "";
+    if (t === active) a.setAttribute("aria-current", "true");
+  });
 </script>
 </body>
 </html>

--- a/public/refresh-preview/index.html
+++ b/public/refresh-preview/index.html
@@ -1153,7 +1153,7 @@ button { font: inherit; cursor: pointer; }
       </div>
       <div>
         <div class="meta-label">From</div>
-        <div class="meta-value">Remote · UK / EU</div>
+        <div class="meta-value">Australia · Worldwide</div>
       </div>
     </div>
   </aside>
@@ -1235,20 +1235,20 @@ button { font: inherit; cursor: pointer; }
         <div class="checkout">
           <div class="checkout-title">Shipping <small>Step 2 of 3</small></div>
           <div class="rate">
-            <div><strong>Royal Mail · 48 hour tracked</strong><div class="rate-eta">Arrives Thu 21 May</div></div>
-            <div class="rate-price">£3.49</div>
+            <div><strong>USPS Ground Advantage · 3–5 day tracked</strong><div class="rate-eta">Arrives Mon 25 May</div></div>
+            <div class="rate-price">$4.85</div>
           </div>
           <div class="rate rate--active">
-            <div><strong>DPD Next Day · before 12:00</strong><div class="rate-eta">Arrives Wed 20 May</div></div>
-            <div class="rate-price">£6.20</div>
+            <div><strong>FedEx Priority Overnight · before 12:00</strong><div class="rate-eta">Arrives Wed 20 May</div></div>
+            <div class="rate-price">$24.40</div>
           </div>
           <div class="rate">
-            <div><strong>Evri Standard · 3–5 day</strong><div class="rate-eta">Arrives Mon 25 May</div></div>
-            <div class="rate-price">£2.10</div>
+            <div><strong>Australia Post · Express 2 day</strong><div class="rate-eta">Arrives Thu 21 May</div></div>
+            <div class="rate-price">$7.60</div>
           </div>
           <div class="rate">
-            <div><strong>UPS International Saver</strong><div class="rate-eta">Arrives Fri 22 May</div></div>
-            <div class="rate-price">£14.85</div>
+            <div><strong>DHL Express Worldwide</strong><div class="rate-eta">Arrives Fri 22 May</div></div>
+            <div class="rate-price">$32.50</div>
           </div>
         </div>
       </div>

--- a/public/refresh-preview/index.html
+++ b/public/refresh-preview/index.html
@@ -1280,17 +1280,24 @@ button { font: inherit; cursor: pointer; }
 </footer>
 
 <script>
-  // Stagger reveal on scroll
-  const io = new IntersectionObserver((entries) => {
-    for (const e of entries) {
-      if (e.isIntersecting) {
-        e.target.classList.add("in");
-        io.unobserve(e.target);
-      }
-    }
-  }, { rootMargin: "-8% 0px -8% 0px", threshold: 0.05 });
+  // ?static=1 — bypass reveal animations (used for screenshot capture)
+  const STATIC = new URLSearchParams(location.search).has("static");
+  const els = document.querySelectorAll(".reveal");
 
-  document.querySelectorAll(".reveal").forEach(el => io.observe(el));
+  if (STATIC) {
+    els.forEach(el => el.classList.add("in"));
+  } else {
+    // Stagger reveal on scroll
+    const io = new IntersectionObserver((entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          e.target.classList.add("in");
+          io.unobserve(e.target);
+        }
+      }
+    }, { rootMargin: "-8% 0px -8% 0px", threshold: 0.05 });
+    els.forEach(el => io.observe(el));
+  }
 </script>
 </body>
 </html>

--- a/public/refresh-preview/second.html
+++ b/public/refresh-preview/second.html
@@ -1,0 +1,1365 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>NITSOF — Studio Black Preview</title>
+<meta name="description" content="Directional preview of a refreshed NITSOF identity: Studio Black variant — Space Grotesk + DM Sans, dark theme." />
+
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,400&family=JetBrains+Mono:wght@400;500&display=swap" />
+
+<style>
+/* =========================================================================
+   NITSOF — Studio Black preview
+   Font: Space Grotesk (display) + DM Sans (body) + JetBrains Mono (labels)
+   Palette: near-black bg, electric orange accent, signal green
+   ========================================================================= */
+
+:root {
+  --bg:           #07080B;
+  --surface:      #0D0F13;
+  --surface-2:    #131720;
+  --ink:          #F8F9FA;
+  --ink-soft:     #9EA3AD;
+  --ink-mute:     #52566090;
+  --rule:         rgba(248,249,250,0.07);
+  --rule-strong:  rgba(248,249,250,0.12);
+  --orange:       #FF4500;
+  --orange-soft:  rgba(255,69,0,0.10);
+  --orange-glow:  rgba(255,69,0,0.22);
+  --signal:       #00FF88;
+  --signal-soft:  rgba(0,255,136,0.15);
+
+  --pad: clamp(1.25rem, 4vw, 3rem);
+  --max: 1440px;
+
+  --font-display: "Space Grotesk", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-body:    "DM Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+body {
+  font-family: var(--font-body);
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.6;
+  background: var(--bg);
+  color: var(--ink);
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a { color: inherit; text-decoration: none; }
+button { font: inherit; cursor: pointer; }
+::selection { background: var(--orange); color: var(--bg); }
+
+/* -------------------------------------------------------------------------
+   VARIANT BADGE
+   ------------------------------------------------------------------------- */
+.variant-badge {
+  position: fixed;
+  top: 0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 90;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.75rem;
+  background: var(--orange);
+  color: var(--bg);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  pointer-events: none;
+  font-weight: 500;
+}
+
+/* -------------------------------------------------------------------------
+   TICKER
+   ------------------------------------------------------------------------- */
+.ticker {
+  position: relative;
+  z-index: 30;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(82,86,96,0.9);
+  overflow: hidden;
+  background: var(--surface);
+}
+.ticker-track {
+  display: flex;
+  gap: 3rem;
+  white-space: nowrap;
+  padding: 0.65rem 0;
+  width: max-content;
+  animation: ticker-scroll 60s linear infinite;
+}
+.ticker-item { display: inline-flex; align-items: center; gap: .6rem; }
+.ticker-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: rgba(82,86,96,.5);
+}
+.ticker-item--live .ticker-dot {
+  background: var(--signal);
+  box-shadow: 0 0 0 4px var(--signal-soft);
+  animation: pulse 1.8s ease-in-out infinite;
+}
+.ticker-item strong { color: var(--ink); font-weight: 500; }
+
+@keyframes ticker-scroll {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 4px var(--signal-soft); }
+  50%       { box-shadow: 0 0 0 9px rgba(0,255,136,0); }
+}
+
+/* -------------------------------------------------------------------------
+   NAV
+   ------------------------------------------------------------------------- */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 25;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 2rem;
+  padding: 1.1rem var(--pad);
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--rule);
+}
+.wordmark {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+}
+.wordmark .dot {
+  width: 7px; height: 7px;
+  background: var(--orange);
+  border-radius: 1px;
+  transform: translateY(-2px);
+  display: inline-block;
+}
+.nav-links {
+  display: flex;
+  justify-self: center;
+  gap: 2.25rem;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.nav-links a {
+  color: rgba(158,163,173,0.8);
+  transition: color .2s ease;
+  position: relative;
+  padding-bottom: 0.2rem;
+}
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -3px;
+  height: 1px;
+  background: var(--orange);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform .35s cubic-bezier(.2,.7,.2,1);
+}
+.nav-links a:hover { color: var(--ink); }
+.nav-links a:hover::after { transform: scaleX(1); }
+@media (max-width: 760px) { .nav-links { display: none; } }
+
+.nav-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  padding: 0.55rem 1.1rem;
+  background: var(--orange);
+  color: var(--bg);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  transition: opacity .2s ease, transform .25s ease;
+}
+.nav-cta:hover { opacity: .85; transform: translateY(-1px); }
+
+/* -------------------------------------------------------------------------
+   HERO — full viewport, content anchored to bottom
+   ------------------------------------------------------------------------- */
+.hero {
+  position: relative;
+  min-height: 92vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  overflow: hidden;
+}
+
+/* Fine grid background */
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--rule) 1px, transparent 1px),
+    linear-gradient(90deg, var(--rule) 1px, transparent 1px);
+  background-size: 72px 72px;
+  pointer-events: none;
+  z-index: 0;
+  mask-image: linear-gradient(to bottom, transparent 0%, black 25%, black 65%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 25%, black 65%, transparent 100%);
+}
+
+/* Soft orange glow at top-right */
+.hero::after {
+  content: "";
+  position: absolute;
+  top: -20%;
+  right: -10%;
+  width: 60vw;
+  height: 60vw;
+  background: radial-gradient(circle, var(--orange-glow) 0%, transparent 65%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hero-inner {
+  position: relative;
+  z-index: 2;
+  max-width: var(--max);
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 var(--pad);
+}
+
+.hero-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--orange);
+  margin-bottom: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+}
+.hero-eyebrow::before {
+  content: "";
+  width: 32px; height: 1px;
+  background: var(--orange);
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.hero h1 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(3.2rem, 9.5vw, 9.5rem);
+  line-height: 0.92;
+  letter-spacing: -0.04em;
+  color: var(--ink);
+  margin-bottom: clamp(2.5rem, 5vw, 4rem);
+  text-wrap: balance;
+}
+.hero h1 .accent { color: var(--orange); }
+
+/* Buttons row */
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: clamp(3rem, 6vw, 5rem);
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 1rem 1.7rem;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: 4px;
+  transition: transform .3s cubic-bezier(.2,.7,.2,1), opacity .2s ease, background .25s ease, color .25s ease;
+}
+.btn--primary {
+  background: var(--orange);
+  color: var(--bg);
+  font-weight: 600;
+}
+.btn--primary:hover { opacity: .85; transform: translateY(-2px); }
+.btn--ghost {
+  border: 1px solid var(--rule-strong);
+  color: var(--ink-soft);
+}
+.btn--ghost:hover { border-color: var(--ink-soft); color: var(--ink); transform: translateY(-2px); }
+
+/* Stat bar */
+.hero-bar {
+  border-top: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+}
+@media (max-width: 640px) {
+  .hero-bar { grid-template-columns: 1fr 1fr; }
+}
+.hero-stat {
+  padding: 1.4rem 0 1.4rem;
+  padding-right: 1.5rem;
+  border-right: 1px solid var(--rule);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.hero-stat:last-child { border-right: 0; }
+.hero-stat + .hero-stat { padding-left: 1.5rem; }
+.stat-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(82,86,96,.9);
+}
+.stat-value {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  letter-spacing: -0.01em;
+}
+.live-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--signal);
+  box-shadow: 0 0 0 3px var(--signal-soft);
+  flex-shrink: 0;
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+/* -------------------------------------------------------------------------
+   MANIFESTO — horizontal rows
+   ------------------------------------------------------------------------- */
+.manifesto {
+  background: var(--surface);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+.manifesto-inner {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 0 var(--pad);
+}
+.principle {
+  display: grid;
+  grid-template-columns: 3.5rem 1fr 1fr;
+  gap: 1.5rem 3.5rem;
+  align-items: start;
+  padding: 2.75rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+.principle:last-child { border-bottom: 0; }
+@media (max-width: 768px) {
+  .principle {
+    grid-template-columns: 2.5rem 1fr;
+    gap: 1rem 1.5rem;
+  }
+  .principle p { grid-column: 2; }
+}
+.principle-num {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: var(--orange);
+  padding-top: 0.35rem;
+  font-weight: 500;
+}
+.principle h3 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(1.45rem, 2.8vw, 2rem);
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+}
+.principle p {
+  font-size: 0.95rem;
+  color: var(--ink-soft);
+  max-width: 44ch;
+  line-height: 1.7;
+}
+
+/* -------------------------------------------------------------------------
+   SHARED SECTION HELPERS
+   ------------------------------------------------------------------------- */
+.section {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 9vw, 7rem) var(--pad);
+}
+.section-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--orange);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
+}
+.section-label::before { content: "//"; opacity: .45; font-weight: 400; }
+
+.section-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: clamp(3rem, 6vw, 5rem);
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--rule);
+}
+.section-head-text {}
+.section-head h2 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  letter-spacing: -0.04em;
+  line-height: 1;
+  margin-top: 0.5rem;
+}
+.section-head p {
+  font-size: 0.9rem;
+  max-width: 30ch;
+  color: var(--ink-soft);
+  line-height: 1.65;
+  text-align: right;
+}
+@media (max-width: 640px) { .section-head p { text-align: left; max-width: unset; } }
+
+/* -------------------------------------------------------------------------
+   CAPABILITIES — numbered list rows
+   ------------------------------------------------------------------------- */
+.cap-list { display: flex; flex-direction: column; }
+
+.cap-row {
+  display: grid;
+  grid-template-columns: 3.5rem 1fr auto;
+  gap: 1.5rem 2.5rem;
+  align-items: center;
+  padding: 2.25rem 0;
+  border-top: 1px solid var(--rule);
+  position: relative;
+  transition: background .2s ease;
+  border-radius: 0;
+}
+.cap-row:last-child { border-bottom: 1px solid var(--rule); }
+
+@media (max-width: 640px) {
+  .cap-row { grid-template-columns: 2.5rem 1fr; }
+  .cap-arrow { display: none; }
+}
+
+/* Subtle hover: extend bg edge-to-edge */
+.cap-row::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  left: calc(var(--pad) * -1);
+  right: calc(var(--pad) * -1);
+  background: var(--surface);
+  opacity: 0;
+  transition: opacity .2s ease;
+  z-index: -1;
+  border-radius: 0;
+}
+.cap-row:hover::before { opacity: 1; }
+.cap-row:hover .cap-num { color: var(--orange); }
+.cap-row:hover .cap-arrow { transform: translate(4px, -4px); color: var(--orange); }
+
+.cap-num {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  color: rgba(82,86,96,.8);
+  transition: color .2s ease;
+  font-weight: 400;
+}
+.cap-body {}
+.cap-body h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: clamp(1.2rem, 2.4vw, 1.65rem);
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  margin-bottom: 0.5rem;
+}
+.cap-body p {
+  font-size: 0.92rem;
+  color: var(--ink-soft);
+  max-width: 56ch;
+  line-height: 1.65;
+}
+.cap-arrow {
+  color: rgba(82,86,96,.6);
+  transition: transform .35s cubic-bezier(.2,.7,.2,1), color .2s ease;
+  flex-shrink: 0;
+  width: 22px; height: 22px;
+}
+
+/* -------------------------------------------------------------------------
+   SELECTED WORK — full-width alternating
+   ------------------------------------------------------------------------- */
+.work { display: flex; flex-direction: column; gap: 0; }
+
+.case {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+  padding: 4rem 0;
+  border-top: 1px solid var(--rule);
+}
+.case:last-child { border-bottom: 1px solid var(--rule); }
+
+@media (min-width: 900px) {
+  .case { grid-template-columns: 1fr 1fr; gap: 5rem; align-items: center; }
+  .case.case--reversed .case-frame { order: 2; }
+  .case.case--reversed .case-info  { order: 1; }
+}
+
+.case-frame {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border-radius: 8px;
+  overflow: hidden;
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  border: 1px solid var(--rule-strong);
+  transition: transform .5s cubic-bezier(.2,.7,.2,1), box-shadow .5s ease;
+}
+.case:hover .case-frame {
+  transform: translateY(-5px);
+  box-shadow: 0 24px 64px rgba(0,0,0,.5), 0 0 0 1px var(--rule-strong);
+}
+.case-frame--carrier { background: linear-gradient(148deg, #0b153f 0%, #07080B 58%); }
+.case-frame--sku     { background: linear-gradient(148deg, #121820 0%, #07080B 62%); }
+
+/* Window chrome */
+.window-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: rgba(248,249,250,0.38);
+}
+.window-bar .dots { display: flex; gap: 5px; }
+.window-bar .dots span {
+  width: 9px; height: 9px; border-radius: 50%;
+  background: rgba(248,249,250,0.14);
+}
+.window-bar .url {
+  margin-left: 0.9rem;
+  padding: 0.2rem 0.65rem;
+  background: rgba(248,249,250,0.07);
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+}
+
+/* Carrier Rates mock */
+.checkout {
+  flex: 1;
+  background: #F4EFE6;
+  border-radius: 5px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  color: #0A0908;
+}
+.checkout-title {
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.checkout-title small {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #6C6660;
+}
+.rate {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.55rem 0.7rem;
+  background: #ECE6D7;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: #0A0908;
+}
+.rate--active {
+  background: #0A0908;
+  color: #F4EFE6;
+  outline: 2px solid #FF4500;
+  outline-offset: -2px;
+}
+.rate strong { font-weight: 500; letter-spacing: 0.02em; }
+.rate-eta { color: #6C6660; font-size: 9px; }
+.rate--active .rate-eta { color: rgba(244,239,230,.55); }
+.rate-price {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+/* SKU Manager mock */
+.dash {
+  flex: 1;
+  background: #F4EFE6;
+  border-radius: 5px;
+  padding: 0.8rem;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 0.55rem;
+  color: #0A0908;
+}
+.dash-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.dash-head small {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #6C6660;
+}
+.dash-table {
+  display: grid;
+  grid-template-columns: 1fr 0.6fr 0.5fr 0.5fr;
+  gap: 0.3rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  align-content: start;
+}
+.dash-table .th {
+  font-family: var(--font-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #6C6660;
+  font-size: 8.5px;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid rgba(26,24,22,0.1);
+}
+.dash-table .td {
+  padding: 0.32rem 0;
+  border-bottom: 1px solid rgba(26,24,22,0.07);
+  color: #0A0908;
+}
+.dash-table .pill {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 8px;
+  letter-spacing: 0.04em;
+}
+.pill--live { background: rgba(0,200,100,0.18); color: #0A0908; }
+.pill--draft { background: #ECE6D7; color: #6C6660; }
+
+/* Case info side */
+.case-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1.35rem;
+}
+.case-status {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(82,86,96,.9);
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+}
+.case-status .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--signal);
+  box-shadow: 0 0 0 3px var(--signal-soft);
+}
+.case-name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 4.5vw, 3.2rem);
+  letter-spacing: -0.04em;
+  line-height: 0.95;
+}
+.case-desc {
+  font-size: 0.95rem;
+  color: var(--ink-soft);
+  max-width: 42ch;
+  line-height: 1.7;
+}
+.case-link {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: .55rem;
+  color: var(--orange);
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid var(--orange);
+  width: fit-content;
+  transition: gap .25s ease, opacity .2s ease;
+}
+.case-link:hover { gap: .85rem; opacity: .8; }
+
+/* -------------------------------------------------------------------------
+   PROCESS — dark surface, oversized numbers
+   ------------------------------------------------------------------------- */
+.process-wrap {
+  background: var(--surface);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+.process-inner {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 9vw, 7rem) var(--pad);
+}
+.process-head {
+  margin-bottom: clamp(3rem, 6vw, 5rem);
+}
+.process-head h2 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  letter-spacing: -0.04em;
+  line-height: 1;
+  margin-top: 0.5rem;
+}
+
+.timeline {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+@media (min-width: 820px) {
+  .timeline {
+    grid-template-columns: repeat(4, 1fr);
+    border-top: 1px solid var(--rule);
+  }
+  .step { border-right: 1px solid var(--rule); border-top: 0; }
+  .step:last-child { border-right: 0; }
+}
+
+.step {
+  padding: 2.25rem 2rem 2.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-top: 1px solid var(--rule);
+  position: relative;
+  overflow: hidden;
+}
+.step-num {
+  font-family: var(--font-display);
+  font-size: clamp(4rem, 8vw, 6rem);
+  font-weight: 700;
+  letter-spacing: -0.05em;
+  color: var(--orange);
+  line-height: 1;
+  opacity: 0.18;
+  user-select: none;
+}
+.step h4 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.2rem;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  color: var(--ink);
+}
+.step p {
+  font-size: 0.88rem;
+  color: var(--ink-soft);
+  max-width: 28ch;
+  line-height: 1.65;
+}
+
+/* -------------------------------------------------------------------------
+   PULL QUOTE
+   ------------------------------------------------------------------------- */
+.pullquote {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(5rem, 12vw, 10rem) var(--pad);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3.5rem;
+}
+@media (min-width: 900px) {
+  .pullquote { grid-template-columns: minmax(0,1fr) 15rem; gap: 5rem; align-items: end; }
+}
+.pullquote blockquote {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(2rem, 5.5vw, 4rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+  text-wrap: balance;
+}
+.pullquote blockquote em {
+  font-style: normal;
+  color: var(--orange);
+  font-weight: 700;
+}
+.attribution {
+  border-top: 1px solid var(--rule);
+  padding-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.attribution .name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+}
+.attribution .role {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(82,86,96,.9);
+}
+.attribution .others {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: var(--ink-soft);
+}
+.attribution .others .o {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 0.3rem;
+}
+.attribution .others .o span:last-child {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(82,86,96,.9);
+}
+
+/* -------------------------------------------------------------------------
+   CTA — full orange
+   ------------------------------------------------------------------------- */
+.cta {
+  background: var(--orange);
+  color: var(--bg);
+  position: relative;
+  overflow: hidden;
+}
+.cta::before {
+  content: "";
+  position: absolute;
+  right: -15%;
+  top: -80%;
+  width: 70vw; height: 70vw;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(0,0,0,0.18), transparent 65%);
+  pointer-events: none;
+}
+.cta-inner {
+  position: relative;
+  z-index: 2;
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 10vw, 8rem) var(--pad);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+}
+@media (min-width: 900px) {
+  .cta-inner { grid-template-columns: 1.5fr 1fr; gap: 4rem; align-items: end; }
+}
+.cta h2 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.2rem, 6vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  color: var(--bg);
+  text-wrap: balance;
+}
+.cta .lead {
+  color: rgba(7,8,11,.65);
+  max-width: 36ch;
+  margin-top: 1.5rem;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+.cta-aside {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  align-self: end;
+}
+.cta-email {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(7,8,11,.6);
+}
+.cta-email a {
+  display: block;
+  font-family: var(--font-display);
+  text-transform: none;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.1rem, 2.2vw, 1.55rem);
+  color: var(--bg);
+  font-weight: 600;
+  margin-top: 0.4rem;
+  border-bottom: 1px solid rgba(7,8,11,.25);
+  padding-bottom: 0.7rem;
+  transition: opacity .25s ease;
+}
+.cta-email a:hover { opacity: .65; }
+.cta-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 1.4rem;
+  background: var(--bg);
+  color: var(--ink);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  transition: transform .25s ease, opacity .2s ease;
+}
+.cta-btn:hover { transform: translateY(-2px); opacity: .9; }
+
+/* -------------------------------------------------------------------------
+   FOOTER
+   ------------------------------------------------------------------------- */
+.footer {
+  border-top: 1px solid var(--rule);
+  padding: 2.5rem var(--pad);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(82,86,96,.9);
+  max-width: var(--max);
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+}
+.footer a:hover { color: var(--ink); }
+
+/* -------------------------------------------------------------------------
+   REVEAL ANIMATIONS
+   ------------------------------------------------------------------------- */
+.reveal {
+  opacity: 0;
+  transform: translateY(22px);
+  transition: opacity .9s cubic-bezier(.2,.7,.2,1), transform .9s cubic-bezier(.2,.7,.2,1);
+}
+.reveal.in {
+  opacity: 1;
+  transform: translateY(0);
+}
+.reveal:nth-child(2) { transition-delay: 0.08s; }
+.reveal:nth-child(3) { transition-delay: 0.16s; }
+.reveal:nth-child(4) { transition-delay: 0.24s; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  .reveal { opacity: 1; transform: none; }
+}
+</style>
+</head>
+<body>
+
+<!-- VARIANT BADGE ---------------------------------------------------------- -->
+<div class="variant-badge" aria-hidden="true">E · Studio Black — Space Grotesk + DM Sans</div>
+
+<!-- TICKER ----------------------------------------------------------------- -->
+<div class="ticker" aria-hidden="true">
+  <div class="ticker-track">
+    <span class="ticker-item ticker-item--live"><span class="ticker-dot"></span> <strong>Now shipping</strong> · Carrier Rates v2.1 — live in 240+ stores</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> AI-augmented delivery · est. 2024</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Currently accepting Q3 engagements</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Software ↔ thought · velocity 4.2×</span>
+    <span class="ticker-item ticker-item--live"><span class="ticker-dot"></span> <strong>Now shipping</strong> · Carrier Rates v2.1 — live in 240+ stores</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> AI-augmented delivery · est. 2024</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Currently accepting Q3 engagements</span>
+    <span class="ticker-item"><span class="ticker-dot"></span> Software ↔ thought · velocity 4.2×</span>
+  </div>
+</div>
+
+<!-- NAV -------------------------------------------------------------------- -->
+<header class="nav">
+  <a class="wordmark" href="#">
+    NITSOF<span class="dot" aria-hidden="true"></span>
+  </a>
+  <nav class="nav-links" aria-label="Primary">
+    <a href="#capabilities">Capabilities</a>
+    <a href="#work">Work</a>
+    <a href="#process">Process</a>
+    <a href="#about">Studio</a>
+  </nav>
+  <a class="nav-cta" href="#contact">
+    Start a project
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+  </a>
+</header>
+
+<!-- HERO ------------------------------------------------------------------- -->
+<section class="hero">
+  <div class="hero-inner">
+    <p class="hero-eyebrow reveal">An AI-native software studio</p>
+    <h1 class="reveal">
+      Software,<br>
+      shipped at the<br>
+      speed of <span class="accent">thought.</span>
+    </h1>
+    <div class="hero-actions reveal">
+      <a class="btn btn--primary" href="#work">
+        See selected work
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+      </a>
+      <a class="btn btn--ghost" href="#contact">Begin a project</a>
+    </div>
+    <div class="hero-bar reveal">
+      <div class="hero-stat">
+        <span class="stat-label">Studio</span>
+        <span class="stat-value">NITSOF</span>
+      </div>
+      <div class="hero-stat">
+        <span class="stat-label">Est.</span>
+        <span class="stat-value">2024</span>
+      </div>
+      <div class="hero-stat">
+        <span class="stat-label">From</span>
+        <span class="stat-value">Australia · Worldwide</span>
+      </div>
+      <div class="hero-stat">
+        <span class="stat-label">Capacity</span>
+        <span class="stat-value">
+          <span class="live-dot" aria-hidden="true"></span>
+          Open · Q3 2026
+        </span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- MANIFESTO -------------------------------------------------------------- -->
+<section class="manifesto" aria-labelledby="manifesto-heading">
+  <div class="manifesto-inner">
+    <div class="principle reveal">
+      <span class="principle-num" aria-hidden="true">01</span>
+      <h3 id="manifesto-heading">Simplicity is the feature.</h3>
+      <p>We strip out everything that doesn't earn its place. Fewer dependencies, fewer screens, fewer meetings. The shortest path from problem to production.</p>
+    </div>
+    <div class="principle reveal">
+      <span class="principle-num" aria-hidden="true">02</span>
+      <h3>Confidence in craft.</h3>
+      <p>We don't ship demos. We ship software our clients depend on to run their business — measured in uptime, revenue, and the quality of a sleepless night avoided.</p>
+    </div>
+    <div class="principle reveal">
+      <span class="principle-num" aria-hidden="true">03</span>
+      <h3>Building the future, now.</h3>
+      <p>AI sits inside our delivery loop, not as a feature on a slide. The pace this enables is the only thing that lets a four-person team out-ship a fifty-person one.</p>
+    </div>
+  </div>
+</section>
+
+<!-- CAPABILITIES ----------------------------------------------------------- -->
+<section class="section" id="capabilities">
+  <div class="section-head">
+    <div class="section-head-text">
+      <span class="section-label">Capabilities</span>
+      <h2>Four disciplines, one studio.</h2>
+    </div>
+    <p>Each engagement is led by a senior engineer who stays through delivery. No handoffs, no juniors learning on your time.</p>
+  </div>
+
+  <div class="cap-list">
+    <article class="cap-row reveal">
+      <span class="cap-num" aria-hidden="true">01</span>
+      <div class="cap-body">
+        <h3>Product archaeology.</h3>
+        <p>We map what's actually there before adding anything new — most teams already have 70% of what they need, just badly arranged.</p>
+      </div>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 17L17 7M9 7h8v8"/></svg>
+    </article>
+    <article class="cap-row reveal">
+      <span class="cap-num" aria-hidden="true">02</span>
+      <div class="cap-body">
+        <h3>AI-augmented engineering.</h3>
+        <p>Senior engineers paired with AI throughout — design, code, review, QA. Same craft, 3–5× the throughput.</p>
+      </div>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 17L17 7M9 7h8v8"/></svg>
+    </article>
+    <article class="cap-row reveal">
+      <span class="cap-num" aria-hidden="true">03</span>
+      <div class="cap-body">
+        <h3>Production from day one.</h3>
+        <p>Every commit deploys. No staging-forever environments — real users, real load, measured from the first week.</p>
+      </div>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 17L17 7M9 7h8v8"/></svg>
+    </article>
+    <article class="cap-row reveal">
+      <span class="cap-num" aria-hidden="true">04</span>
+      <div class="cap-body">
+        <h3>Stay in the loop.</h3>
+        <p>We don't disappear at launch. Monthly cadence, real metrics, the kind of partner you keep on speed dial.</p>
+      </div>
+      <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 17L17 7M9 7h8v8"/></svg>
+    </article>
+  </div>
+</section>
+
+<!-- SELECTED WORK ---------------------------------------------------------- -->
+<section class="section" id="work" style="padding-top: 0;">
+  <div class="section-head">
+    <div class="section-head-text">
+      <span class="section-label">Selected work</span>
+      <h2>Built in production. Not in a deck.</h2>
+    </div>
+    <p>A small selection of the studio's recent work. Full case studies on request.</p>
+  </div>
+
+  <div class="work">
+
+    <article class="case reveal">
+      <div class="case-frame case-frame--carrier">
+        <div class="window-bar">
+          <div class="dots"><span></span><span></span><span></span></div>
+          <div class="url">checkout.acme-store.com</div>
+        </div>
+        <div class="checkout">
+          <div class="checkout-title">Shipping <small>Step 2 of 3</small></div>
+          <div class="rate">
+            <div><strong>USPS Ground Advantage · 3–5 day tracked</strong><div class="rate-eta">Arrives Mon 25 May</div></div>
+            <div class="rate-price">$4.85</div>
+          </div>
+          <div class="rate rate--active">
+            <div><strong>FedEx Priority Overnight · before 12:00</strong><div class="rate-eta">Arrives Wed 20 May</div></div>
+            <div class="rate-price">$24.40</div>
+          </div>
+          <div class="rate">
+            <div><strong>Australia Post · Express 2 day</strong><div class="rate-eta">Arrives Thu 21 May</div></div>
+            <div class="rate-price">$7.60</div>
+          </div>
+          <div class="rate">
+            <div><strong>DHL Express Worldwide</strong><div class="rate-eta">Arrives Fri 22 May</div></div>
+            <div class="rate-price">$32.50</div>
+          </div>
+        </div>
+      </div>
+      <div class="case-info">
+        <span class="case-status"><span class="dot" aria-hidden="true"></span> Live</span>
+        <h3 class="case-name">Live Carrier Rates</h3>
+        <p class="case-desc">A published Shopify app that surfaces real-time carrier pricing inside checkout — the moment shoppers decide to buy or bail.</p>
+        <a class="case-link" href="https://apps.shopify.com/live-carrier-rates" target="_blank" rel="noopener noreferrer">
+          View on the Shopify App Store
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </a>
+      </div>
+    </article>
+
+    <article class="case case--reversed reveal">
+      <div class="case-frame case-frame--sku">
+        <div class="window-bar">
+          <div class="dots"><span></span><span></span><span></span></div>
+          <div class="url">app.skumanager.com — Catalog</div>
+        </div>
+        <div class="dash">
+          <div class="dash-head">
+            12,408 SKUs <small>Updated 3 min ago</small>
+          </div>
+          <div class="dash-table">
+            <div class="th">SKU</div><div class="th">Variant</div><div class="th">Stock</div><div class="th">Status</div>
+            <div class="td">NSF-1184-BLK</div><div class="td">Standard</div><div class="td">412</div><div class="td"><span class="pill pill--live">Live</span></div>
+            <div class="td">NSF-2210-GRY</div><div class="td">Premium</div><div class="td">38</div><div class="td"><span class="pill pill--live">Live</span></div>
+            <div class="td">NSF-9001-EVG</div><div class="td">Limited</div><div class="td">0</div><div class="td"><span class="pill pill--draft">Draft</span></div>
+            <div class="td">NSF-4470-RED</div><div class="td">Standard</div><div class="td">1,204</div><div class="td"><span class="pill pill--live">Live</span></div>
+            <div class="td">NSF-7732-CRM</div><div class="td">Bundle</div><div class="td">29</div><div class="td"><span class="pill pill--live">Live</span></div>
+          </div>
+        </div>
+      </div>
+      <div class="case-info">
+        <span class="case-status"><span class="dot" aria-hidden="true"></span> Live</span>
+        <h3 class="case-name">SKU Manager</h3>
+        <p class="case-desc">Operations tooling for merchandising teams running complex catalogues at scale. Built for the businesses where product data is the business.</p>
+        <a class="case-link" href="https://skumanager.com" target="_blank" rel="noopener noreferrer">
+          Visit skumanager.com
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </a>
+      </div>
+    </article>
+
+  </div>
+</section>
+
+<!-- PROCESS ---------------------------------------------------------------- -->
+<section class="process-wrap" id="process">
+  <div class="process-inner">
+    <div class="process-head">
+      <span class="section-label">How we work</span>
+      <h2>Four weeks, not four months.</h2>
+    </div>
+
+    <div class="timeline">
+      <article class="step reveal">
+        <span class="step-num" aria-hidden="true">01</span>
+        <h4>Frame the real problem.</h4>
+        <p>We map the system, the team, and the constraints. Output: one page that everyone signs.</p>
+      </article>
+      <article class="step reveal">
+        <span class="step-num" aria-hidden="true">02</span>
+        <h4>Ship something that runs.</h4>
+        <p>First commit on day two. By Friday it's in front of users — even if rough.</p>
+      </article>
+      <article class="step reveal">
+        <span class="step-num" aria-hidden="true">03</span>
+        <h4>Refine in public.</h4>
+        <p>Measure, cut, sharpen. AI handles the boilerplate so humans do the judgement work.</p>
+      </article>
+      <article class="step reveal">
+        <span class="step-num" aria-hidden="true">04</span>
+        <h4>Hand over, or stay close.</h4>
+        <p>Permanent ownership transfer or a monthly retainer — your call, every quarter.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- PULL QUOTE ------------------------------------------------------------- -->
+<section class="pullquote" id="about">
+  <blockquote class="reveal">
+    "NITSOF cut our expected delivery timeline in <em>half</em>. The AI-first approach isn't a pitch — it's just how they actually work, every day, every meeting."
+  </blockquote>
+  <div class="attribution reveal">
+    <div class="name">James Harlow</div>
+    <div class="role">CTO · Apex Logistics Group</div>
+    <div class="others">
+      <div class="o"><span>Priya Mehta</span><span>Stackborn</span></div>
+      <div class="o"><span>Daniel Osei</span><span>Mercia Health</span></div>
+      <div class="o" style="border: 0; padding-bottom: 0;"><span>Maya Lindgren</span><span>Nordpath Retail</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -------------------------------------------------------------------- -->
+<section class="cta" id="contact">
+  <div class="cta-inner">
+    <div class="reveal">
+      <h2>Have something you'd ship if it were easy?</h2>
+      <p class="lead">Tell us what you're trying to build. We respond within one working day with either a plan or an honest reason why we're not the right studio for it.</p>
+    </div>
+    <div class="cta-aside reveal">
+      <div class="cta-email">
+        Direct line
+        <a href="mailto:hello@nitsof.com">hello@nitsof.com</a>
+      </div>
+      <a class="cta-btn" href="mailto:hello@nitsof.com">
+        Start a brief
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER ----------------------------------------------------------------- -->
+<footer class="footer">
+  <span>© 2026 NITSOF · All rights reserved</span>
+  <span><a href="/privacy">Privacy</a> · <a href="mailto:hello@nitsof.com">hello@nitsof.com</a></span>
+  <span>Studio Black preview · v0.1</span>
+</footer>
+
+<script>
+  const params = new URLSearchParams(location.search);
+  const STATIC = params.has("static");
+  const els = document.querySelectorAll(".reveal");
+
+  if (STATIC) {
+    els.forEach(el => el.classList.add("in"));
+  } else {
+    const io = new IntersectionObserver((entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          e.target.classList.add("in");
+          io.unobserve(e.target);
+        }
+      }
+    }, { rootMargin: "-6% 0px -6% 0px", threshold: 0.05 });
+    els.forEach(el => io.observe(el));
+  }
+</script>
+</body>
+</html>

--- a/public/refresh-preview/swiss.html
+++ b/public/refresh-preview/swiss.html
@@ -1,57 +1,24 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-type="swiss">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <meta name="robots" content="noindex" />
-<title>NITSOF — Brand Refresh Preview</title>
-<meta name="description" content="A directional preview of a refreshed NITSOF identity: simplicity, confidence, future." />
+<title>NITSOF — Swiss Modern Preview</title>
+<meta name="description" content="Directional preview of a refreshed NITSOF identity: Swiss Modern variant — General Sans + Switzer, sans-serif." />
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="preconnect" href="https://api.fontshare.com" crossorigin />
 <link rel="preconnect" href="https://cdn.fontshare.com" crossorigin />
 
-<!--
-  Typography schemes — switchable via ?type= (chip in bottom-right of the preview).
-    A (default)  · Editorial Bold     · Fraunces + Manrope        — strong character, expressive italic
-    B (editorial)· Editorial Calm     · Newsreader + Inter Tight  — softer serif, higher legibility
-    C (newsstand)· Newsstand Contrast · Instrument Serif + Inter  — high-contrast, max screen clarity
-    D (swiss)    · Swiss Modern       · General Sans + Switzer    — sans-only, tech-forward
-  All four stylesheets are loaded up front so every scheme paints with the correct
-  fonts (no FOUT). The active scheme is selected by swapping the --font-* CSS variables.
--->
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,200..900,0..100,0..1&family=Manrope:wght@300..700&family=JetBrains+Mono:wght@400;500&display=swap" />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&family=Inter+Tight:ital,wght@0,300..700;1,400..600&display=swap" />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@300..700&display=swap" />
-<link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=general-sans@400,500,600,700&f[]=switzer@300,400,500,600,700&display=swap" />
-
-<script>
-  // Select an active typography scheme by swapping --font-display / --font-body.
-  // Fonts themselves are already loaded via the four <link> tags above.
-  (function () {
-    var t = (new URLSearchParams(location.search).get("type") || "default").toLowerCase();
-    var vars = {
-      "default":   { d: '"Fraunces", "Times New Roman", serif',         b: '"Manrope", -apple-system, BlinkMacSystemFont, system-ui, sans-serif' },
-      "editorial": { d: '"Newsreader", "Times New Roman", serif',       b: '"Inter Tight", -apple-system, BlinkMacSystemFont, system-ui, sans-serif' },
-      "newsstand": { d: '"Instrument Serif", "Times New Roman", serif', b: '"Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif' },
-      "swiss":     { d: '"General Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif',
-                     b: '"Switzer", -apple-system, BlinkMacSystemFont, system-ui, sans-serif' }
-    };
-    var key = vars[t] ? t : "default";
-    var v = vars[key];
-    // Inline style on <html> outranks any later :root rule in a stylesheet,
-    // so the override survives even though the main <style> is parsed after this script.
-    document.documentElement.style.setProperty("--font-display", v.d);
-    document.documentElement.style.setProperty("--font-body", v.b);
-    document.documentElement.setAttribute("data-type", key);
-  })();
-</script>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" />
+<link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=general-sans@300,400,500,600,700&f[]=switzer@300,400,500,600,700&display=swap" />
 
 <style>
 /* =========================================================================
-   NITSOF — refresh preview
-   A single-file directional concept. Not production code.
+   NITSOF — Swiss Modern preview (standalone variant)
+   Font: General Sans (display) + Switzer (body)
    ========================================================================= */
 
 :root {
@@ -69,8 +36,8 @@
   --pad: clamp(1.25rem, 4vw, 3rem);
   --max: 1440px;
 
-  --font-display: "Fraunces", "Times New Roman", serif;
-  --font-body:    "Manrope", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-display: "General Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-body:    "Switzer", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   --font-mono:    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
 }
 
@@ -84,12 +51,11 @@ body {
   background: var(--cream);
   color: var(--ink);
   overflow-x: hidden;
-  font-feature-settings: "ss01", "cv02", "cv11";
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Subtle warm grain that ties the cream canvas together */
+/* Subtle warm grain */
 body::before {
   content: "";
   position: fixed;
@@ -105,6 +71,29 @@ a { color: inherit; text-decoration: none; }
 button { font: inherit; cursor: pointer; }
 
 ::selection { background: var(--cobalt); color: var(--cream); }
+
+/* -------------------------------------------------------------------------
+   VARIANT BADGE — top-left indicator for review context
+   ------------------------------------------------------------------------- */
+.variant-badge {
+  position: fixed;
+  top: 0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 90;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.75rem;
+  background: var(--cobalt);
+  color: var(--cream);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
 
 /* -------------------------------------------------------------------------
    TICKER
@@ -166,10 +155,10 @@ button { font: inherit; cursor: pointer; }
 }
 .wordmark {
   font-family: var(--font-display);
-  font-weight: 600;
-  font-variation-settings: "opsz" 144, "SOFT" 0, "WONK" 0;
-  font-size: 1.25rem;
-  letter-spacing: -0.02em;
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   display: inline-flex;
   align-items: baseline;
   gap: 0.4rem;
@@ -263,18 +252,16 @@ button { font: inherit; cursor: pointer; }
 
 .hero h1 {
   font-family: var(--font-display);
-  font-weight: 350;
-  font-variation-settings: "opsz" 144, "SOFT" 0, "WONK" 1;
+  font-weight: 700;
   font-size: clamp(2.8rem, 8.4vw, 8.5rem);
   line-height: 0.95;
-  letter-spacing: -0.035em;
+  letter-spacing: -0.04em;
   color: var(--ink);
   text-wrap: balance;
 }
 .hero h1 em {
-  font-style: italic;
+  font-style: normal;
   font-weight: 300;
-  font-variation-settings: "opsz" 144, "SOFT" 100, "WONK" 1;
   color: var(--cobalt);
 }
 .hero h1 .underline {
@@ -317,13 +304,13 @@ button { font: inherit; cursor: pointer; }
 }
 .meta-value {
   font-family: var(--font-display);
-  font-weight: 400;
+  font-weight: 500;
   font-size: 1rem;
   letter-spacing: -0.01em;
 }
-.meta-value.serif-bigger {
-  font-size: 1.25rem;
-  font-variation-settings: "opsz" 30;
+.meta-value.big {
+  font-size: 1.2rem;
+  font-weight: 600;
 }
 
 .hero-actions {
@@ -407,14 +394,13 @@ button { font: inherit; cursor: pointer; }
 }
 .principle h3 {
   font-family: var(--font-display);
-  font-weight: 350;
-  font-variation-settings: "opsz" 144, "WONK" 1;
-  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+  font-size: clamp(1.9rem, 3.5vw, 2.6rem);
   line-height: 1;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.03em;
   margin-bottom: 1rem;
 }
-.principle h3 em { font-style: italic; color: var(--cobalt); font-weight: 300; }
+.principle h3 em { font-style: normal; color: var(--cobalt); font-weight: 300; }
 .principle p {
   font-size: 0.95rem;
   color: var(--ink-soft);
@@ -451,14 +437,13 @@ button { font: inherit; cursor: pointer; }
 }
 .section-head h2 {
   font-family: var(--font-display);
-  font-weight: 350;
-  font-variation-settings: "opsz" 144;
+  font-weight: 700;
   font-size: clamp(2rem, 5vw, 3.5rem);
-  letter-spacing: -0.03em;
+  letter-spacing: -0.04em;
   line-height: 1;
   text-wrap: balance;
 }
-.section-head h2 em { font-style: italic; color: var(--cobalt); font-weight: 300; }
+.section-head h2 em { font-style: normal; color: var(--cobalt); font-weight: 300; }
 .section-head .aside {
   font-size: 0.9rem;
   max-width: 26ch;
@@ -500,13 +485,13 @@ button { font: inherit; cursor: pointer; }
 }
 .cap h3 {
   font-family: var(--font-display);
-  font-weight: 400;
-  font-variation-settings: "opsz" 144;
-  font-size: 1.55rem;
+  font-weight: 600;
+  font-size: 1.5rem;
   line-height: 1.05;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.025em;
   margin-top: auto;
 }
+.cap h3 em { font-style: normal; color: inherit; }
 .cap-desc {
   font-size: 0.92rem;
   color: var(--ink-soft);
@@ -535,7 +520,6 @@ button { font: inherit; cursor: pointer; }
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  group: case;
 }
 .case-frame {
   position: relative;
@@ -592,7 +576,7 @@ button { font: inherit; cursor: pointer; }
 .checkout-title {
   font-family: var(--font-display);
   font-size: 0.85rem;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: -0.01em;
   display: flex;
   justify-content: space-between;
@@ -634,8 +618,8 @@ button { font: inherit; cursor: pointer; }
 .rate-price {
   font-family: var(--font-display);
   font-size: 0.95rem;
-  font-weight: 500;
-  letter-spacing: -0.01em;
+  font-weight: 600;
+  letter-spacing: -0.02em;
 }
 
 /* SKU manager mock dashboard */
@@ -653,7 +637,7 @@ button { font: inherit; cursor: pointer; }
   display: flex; justify-content: space-between; align-items: baseline;
   font-family: var(--font-display);
   font-size: 0.85rem;
-  font-weight: 500;
+  font-weight: 600;
 }
 .dash-head small {
   font-family: var(--font-mono);
@@ -716,10 +700,9 @@ button { font: inherit; cursor: pointer; }
 }
 .case-name {
   font-family: var(--font-display);
-  font-weight: 400;
-  font-variation-settings: "opsz" 144;
+  font-weight: 600;
   font-size: 1.65rem;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.03em;
   line-height: 1;
 }
 .case-desc { color: var(--ink-soft); font-size: 0.95rem; max-width: 50ch; }
@@ -792,14 +775,13 @@ button { font: inherit; cursor: pointer; }
 }
 .step h4 {
   font-family: var(--font-display);
-  font-weight: 350;
-  font-variation-settings: "opsz" 100;
-  font-size: 1.55rem;
-  letter-spacing: -0.02em;
+  font-weight: 600;
+  font-size: 1.5rem;
+  letter-spacing: -0.025em;
   line-height: 1.05;
   color: var(--cream);
 }
-.step h4 em { color: var(--signal); font-style: italic; font-weight: 300; }
+.step h4 em { color: var(--signal); font-style: normal; font-weight: 300; }
 .step p {
   font-size: 0.9rem;
   color: color-mix(in srgb, var(--cream) 65%, transparent);
@@ -824,16 +806,15 @@ button { font: inherit; cursor: pointer; }
 .pullquote blockquote {
   font-family: var(--font-display);
   font-weight: 300;
-  font-variation-settings: "opsz" 144, "SOFT" 50, "WONK" 1;
   font-size: clamp(1.8rem, 4.5vw, 3.4rem);
   line-height: 1.05;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.03em;
   text-wrap: balance;
 }
 .pullquote blockquote em {
-  font-style: italic;
+  font-style: normal;
   color: var(--cobalt);
-  font-weight: 300;
+  font-weight: 700;
 }
 .attribution {
   border-top: 1px solid var(--ink);
@@ -844,7 +825,7 @@ button { font: inherit; cursor: pointer; }
 }
 .attribution .name {
   font-family: var(--font-display);
-  font-weight: 500;
+  font-weight: 600;
   font-size: 1rem;
   letter-spacing: -0.01em;
 }
@@ -908,14 +889,13 @@ button { font: inherit; cursor: pointer; }
 
 .cta h2 {
   font-family: var(--font-display);
-  font-weight: 350;
-  font-variation-settings: "opsz" 144, "WONK" 1;
+  font-weight: 700;
   font-size: clamp(2.2rem, 6vw, 5rem);
   line-height: 0.95;
-  letter-spacing: -0.035em;
+  letter-spacing: -0.04em;
   text-wrap: balance;
 }
-.cta h2 em { font-style: italic; color: var(--signal); font-weight: 300; }
+.cta h2 em { font-style: normal; color: var(--signal); font-weight: 300; }
 .cta .lead { color: color-mix(in srgb, var(--cream) 75%, transparent); max-width: 36ch; margin-top: 1.5rem; }
 
 .cta-aside {
@@ -938,7 +918,7 @@ button { font: inherit; cursor: pointer; }
   letter-spacing: -0.01em;
   font-size: clamp(1.2rem, 2.2vw, 1.6rem);
   color: var(--cream);
-  font-weight: 400;
+  font-weight: 500;
   margin-top: 0.4rem;
   border-bottom: 1px solid color-mix(in srgb, var(--cream) 30%, transparent);
   padding-bottom: 0.7rem;
@@ -1003,72 +983,12 @@ button { font: inherit; cursor: pointer; }
   *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
   .reveal { opacity: 1; transform: none; }
 }
-
-/* -------------------------------------------------------------------------
-   TYPE SWITCHER — preview-only chrome (?type=...)
-   Docks bottom-right like a dev tool — never collides with site nav.
-   ------------------------------------------------------------------------- */
-.type-switcher {
-  position: fixed;
-  bottom: 1rem;
-  right: 1rem;
-  z-index: 80;
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.45rem 0.55rem;
-  background: rgba(244, 239, 230, 0.94);
-  backdrop-filter: blur(12px) saturate(160%);
-  -webkit-backdrop-filter: blur(12px) saturate(160%);
-  border: 1px solid rgba(10, 9, 8, 0.14);
-  border-radius: 999px;
-  box-shadow: 0 14px 40px -18px rgba(10, 9, 8, 0.45);
-  font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.68rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--ink-mute);
-  max-width: calc(100vw - 2rem);
-}
-.type-switcher__label {
-  padding: 0 0.45rem 0 0.3rem;
-  border-right: 1px solid rgba(10, 9, 8, 0.14);
-  white-space: nowrap;
-}
-.type-switcher a {
-  text-decoration: none;
-  padding: 0.32rem 0.6rem;
-  border-radius: 999px;
-  color: var(--ink-mute);
-  white-space: nowrap;
-  transition: background 160ms ease, color 160ms ease;
-}
-.type-switcher a:hover { color: var(--ink); background: rgba(10, 9, 8, 0.06); }
-.type-switcher a[aria-current="true"] {
-  background: var(--ink);
-  color: var(--cream);
-}
-@media (max-width: 760px) {
-  .type-switcher {
-    left: 1rem;
-    justify-content: center;
-    flex-wrap: wrap;
-    font-size: 0.6rem;
-  }
-  .type-switcher__label { display: none; }
-}
 </style>
 </head>
 <body>
 
-<!-- TYPE SWITCHER (preview affordance — not part of the proposed UI) -------- -->
-<nav class="type-switcher" aria-label="Typography preview switcher">
-  <span class="type-switcher__label">Type</span>
-  <a data-type="default"   data-title="Fraunces + Manrope">A · Editorial Bold</a>
-  <a data-type="editorial" data-title="Newsreader + Inter Tight">B · Editorial Calm</a>
-  <a data-type="newsstand" data-title="Instrument Serif + Inter">C · Newsstand</a>
-  <a data-type="swiss"     data-title="General Sans + Switzer">D · Swiss Modern</a>
-</nav>
+<!-- VARIANT BADGE ---------------------------------------------------------- -->
+<div class="variant-badge" aria-hidden="true">D · Swiss Modern — General Sans + Switzer</div>
 
 <!-- TICKER ----------------------------------------------------------------- -->
 <div class="ticker" aria-hidden="true">
@@ -1126,7 +1046,7 @@ button { font: inherit; cursor: pointer; }
     <div class="meta-row">
       <div>
         <div class="meta-label">Studio</div>
-        <div class="meta-value serif-bigger">NITSOF</div>
+        <div class="meta-value big">NITSOF</div>
       </div>
       <div>
         <div class="meta-label">Est.</div>
@@ -1192,7 +1112,7 @@ button { font: inherit; cursor: pointer; }
     <article class="cap reveal">
       <span class="cap-num">01 / Strategy</span>
       <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 17L17 7M9 7h8v8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-      <h3>Product <em>archaeology</em>.</h3>
+      <h3>Product archaeology.</h3>
       <p class="cap-desc">We map what's actually there before adding anything new — most teams already have 70% of what they need, just badly arranged.</p>
     </article>
     <article class="cap reveal">
@@ -1204,7 +1124,7 @@ button { font: inherit; cursor: pointer; }
     <article class="cap reveal">
       <span class="cap-num">03 / Ship</span>
       <svg class="cap-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 17L17 7M9 7h8v8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-      <h3>Production from <em>day one</em>.</h3>
+      <h3>Production from day one.</h3>
       <p class="cap-desc">Every commit deploys. No staging-forever environments — real users, real load, measured from the first week.</p>
     </article>
     <article class="cap reveal">
@@ -1336,7 +1256,7 @@ button { font: inherit; cursor: pointer; }
 <!-- PULL QUOTE / TESTIMONIAL ---------------------------------------------- -->
 <section class="pullquote" id="about">
   <blockquote class="reveal">
-    “NITSOF cut our expected delivery timeline in <em>half</em>. The AI-first approach isn't a pitch — it's just how they actually work, every day, every meeting.”
+    "NITSOF cut our expected delivery timeline in <em>half</em>. The AI-first approach isn't a pitch — it's just how they actually work, every day, every meeting."
   </blockquote>
   <div class="attribution reveal">
     <div class="name">James Harlow</div>
@@ -1373,7 +1293,7 @@ button { font: inherit; cursor: pointer; }
 <footer class="footer">
   <span>© 2026 NITSOF · All rights reserved</span>
   <span><a href="/privacy">Privacy</a> · <a href="mailto:hello@nitsof.com">hello@nitsof.com</a></span>
-  <span>Refresh preview · v0.1</span>
+  <span>Swiss Modern preview · v0.1</span>
 </footer>
 
 <script>
@@ -1385,7 +1305,6 @@ button { font: inherit; cursor: pointer; }
   if (STATIC) {
     els.forEach(el => el.classList.add("in"));
   } else {
-    // Stagger reveal on scroll
     const io = new IntersectionObserver((entries) => {
       for (const e of entries) {
         if (e.isIntersecting) {
@@ -1396,19 +1315,6 @@ button { font: inherit; cursor: pointer; }
     }, { rootMargin: "-8% 0px -8% 0px", threshold: 0.05 });
     els.forEach(el => io.observe(el));
   }
-
-  // Type switcher: each chip is a same-page link that swaps the ?type= param
-  // while preserving anything else (e.g. ?static=1).
-  const active = (document.documentElement.getAttribute("data-type") || "default");
-  document.querySelectorAll(".type-switcher a[data-type]").forEach(a => {
-    const t = a.getAttribute("data-type");
-    const next = new URLSearchParams(params);
-    if (t === "default") next.delete("type"); else next.set("type", t);
-    const qs = next.toString();
-    a.href = location.pathname + (qs ? "?" + qs : "") + location.hash;
-    a.title = a.getAttribute("data-title") || "";
-    if (t === active) a.setAttribute("aria-current", "true");
-  });
 </script>
 </body>
 </html>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 :root {
   --background: #ffffff;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,27 +1,1108 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+/* =========================================================
+   DESIGN TOKENS
+   ========================================================= */
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  /* Body palette */
+  --cream:        #F4EFE6;
+  --cream-deep:   #ECE6D7;
+  --ink:          #0A0908;
+  --ink-soft:     #1A1816;
+  --ink-mute:     #6C6660;
+  --rule:         rgba(10,9,8,.1);
+  --rule-light:   rgba(10,9,8,.06);
+  --cobalt:       #1740FF;
+  --signal:       #CAFF39;
+
+  /* Hero palette */
+  --dark:         #07080B;
+  --dark-ink:     #F0EDE8;
+  --dark-mute:    rgba(240,237,232,.45);
+  --dark-rule:    rgba(240,237,232,.08);
+  --dark-rule-s:  rgba(240,237,232,.13);
+  --cobalt-glow:  rgba(23,64,255,.28);
+  --signal-soft:  rgba(202,255,57,.18);
+
+  --pad: clamp(1.25rem, 4vw, 3rem);
+  --max: 1440px;
+
+  --font-display: "General Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-body:    "Switzer", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
+/* =========================================================
+   BASE
+   ========================================================= */
+html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: var(--font-geist-sans);
+  font-family: var(--font-body);
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.55;
+  background: var(--cream);
+  color: var(--ink);
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
+a { color: inherit; text-decoration: none; }
+::selection { background: var(--cobalt); color: var(--cream); }
+
+/* =========================================================
+   GRAIN OVERLAY
+   ========================================================= */
+.grain-overlay {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  opacity: 0;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.04  0 0 0 0 0.035  0 0 0 0 0.03  0 0 0 0.4 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  transition: opacity .6s ease;
+}
+body.past-hero .grain-overlay { opacity: .32; }
+
+/* =========================================================
+   SCROLL PROGRESS
+   ========================================================= */
+#scroll-progress {
+  position: fixed;
+  top: 0; left: 0;
+  width: 0%;
+  height: 2px;
+  background: var(--cobalt);
+  z-index: 200;
+  transition: width .1s linear;
+  pointer-events: none;
+}
+
+/* =========================================================
+   TICKER
+   ========================================================= */
+.ticker {
+  position: relative;
+  z-index: 30;
+  border-bottom: 1px solid var(--dark-rule);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--dark-mute);
+  overflow: hidden;
+  background: var(--dark);
+}
+.ticker-track {
+  display: flex;
+  gap: 3rem;
+  white-space: nowrap;
+  padding: 0.65rem 0;
+  width: max-content;
+  animation: ticker-scroll 60s linear infinite;
+}
+.ticker-item { display: inline-flex; align-items: center; gap: .6rem; }
+.ticker-dot { width: 6px; height: 6px; border-radius: 50%; background: rgba(240,237,232,.2); }
+.ticker-item--live .ticker-dot {
+  background: var(--signal);
+  opacity: 1;
+  box-shadow: 0 0 0 4px var(--signal-soft);
+  animation: pulse 1.8s ease-in-out infinite;
+}
+.ticker-item strong { color: var(--dark-ink); font-weight: 500; }
+@keyframes ticker-scroll { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 4px var(--signal-soft); }
+  50%       { box-shadow: 0 0 0 9px rgba(202,255,57,0); }
+}
+
+/* =========================================================
+   NAV — dark initially, flips to cream past hero
+   ========================================================= */
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 25;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 2rem;
+  padding: 1.1rem var(--pad);
+  background: color-mix(in srgb, var(--dark) 88%, transparent);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--dark-rule);
+  transition: background .5s ease, border-color .5s ease;
+}
+body.past-hero .site-nav {
+  background: color-mix(in srgb, var(--cream) 88%, transparent);
+  border-bottom-color: var(--rule);
+}
+
+.wordmark {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  color: var(--dark-ink);
+  transition: color .5s ease;
+}
+body.past-hero .wordmark { color: var(--ink); }
+.wordmark-dot {
+  width: 8px; height: 8px;
+  background: var(--cobalt);
+  border-radius: 1px;
+  transform: translateY(-2px);
+  flex-shrink: 0;
+}
+
+.nav-links {
+  display: flex;
+  justify-self: center;
+  gap: 2.25rem;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.nav-links a {
+  position: relative;
+  padding: 0.25rem 0;
+  color: var(--dark-mute);
+  transition: color .3s ease;
+}
+.nav-links a:hover { color: var(--dark-ink); }
+body.past-hero .nav-links a { color: var(--ink-mute); }
+body.past-hero .nav-links a:hover { color: var(--ink); }
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -2px;
+  height: 1px;
+  background: var(--cobalt);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform .35s cubic-bezier(.2,.7,.2,1);
+}
+.nav-links a:hover::after { transform: scaleX(1); }
+@media (max-width: 760px) { .nav-links { display: none; } }
+
+.nav-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: .6rem;
+  padding: 0.55rem 1rem;
+  background: var(--cobalt);
+  color: var(--cream);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform .25s ease, opacity .25s ease;
+}
+.nav-cta:hover { opacity: .85; transform: translateY(-1px); }
+
+/* =========================================================
+   HAMBURGER
+   ========================================================= */
+.hamburger {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 32px; height: 32px;
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+}
+.hamburger span {
+  display: block;
+  width: 100%; height: 1.5px;
+  background: var(--dark-ink);
+  transition: transform .3s ease, opacity .3s ease, background .5s ease;
+}
+body.past-hero .hamburger span { background: var(--ink); }
+.hamburger.open span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
+.hamburger.open span:nth-child(2) { opacity: 0; }
+.hamburger.open span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
+@media (max-width: 760px) { .hamburger { display: flex; } }
+
+/* =========================================================
+   MOBILE MENU
+   ========================================================= */
+.mobile-menu {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: var(--dark);
+  z-index: 20;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+}
+.mobile-menu.open { display: flex; }
+.mobile-menu a {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.2rem, 10vw, 3.5rem);
+  letter-spacing: -0.04em;
+  color: var(--dark-ink);
+  transition: color .25s ease;
+}
+.mobile-menu a:hover { color: var(--cobalt); }
+.mobile-menu .menu-cta {
+  margin-top: 1rem;
+  display: inline-flex; align-items: center; gap: .6rem;
+  padding: 0.9rem 1.6rem;
+  background: var(--cobalt);
+  color: var(--cream);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+
+/* =========================================================
+   HERO
+   ========================================================= */
+.hero {
+  position: relative;
+  min-height: 94vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  overflow: hidden;
+  background: var(--dark);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--dark-rule) 1px, transparent 1px),
+    linear-gradient(90deg, var(--dark-rule) 1px, transparent 1px);
+  background-size: 72px 72px;
+  pointer-events: none;
+  z-index: 0;
+  mask-image: linear-gradient(to bottom, transparent 0%, black 20%, black 60%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 20%, black 60%, transparent 100%);
+}
+.hero-glow {
+  position: absolute;
+  top: -15%; right: -8%;
+  width: 65vw; height: 65vw;
+  background: radial-gradient(circle, var(--cobalt-glow) 0%, transparent 60%);
+  pointer-events: none;
+  z-index: 0;
+}
+.hero-glow-2 {
+  position: absolute;
+  bottom: -10%; left: -5%;
+  width: 40vw; height: 40vw;
+  background: radial-gradient(circle, rgba(202,255,57,.06) 0%, transparent 65%);
+  pointer-events: none;
+  z-index: 0;
+}
+.hero-inner {
+  position: relative;
+  z-index: 2;
+  max-width: var(--max);
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 var(--pad);
+}
+.hero-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--cobalt);
+  margin-bottom: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+}
+.hero-eyebrow::before {
+  content: "";
+  width: 32px; height: 1px;
+  background: var(--cobalt);
+  display: inline-block;
+  flex-shrink: 0;
+}
+.hero h1 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(3rem, 9.5vw, 9.5rem);
+  line-height: 0.92;
+  letter-spacing: -0.04em;
+  color: var(--dark-ink);
+  margin-bottom: clamp(2.5rem, 5vw, 4rem);
+  text-wrap: balance;
+}
+.hero h1 em {
+  font-style: normal;
+  font-weight: 300;
+  color: var(--cobalt);
+}
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: clamp(3rem, 5vw, 4.5rem);
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 1.05rem 1.6rem;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform .3s cubic-bezier(.2,.7,.2,1), background .25s ease, color .25s ease, opacity .25s ease;
+}
+.btn--primary { background: var(--cobalt); color: var(--cream); }
+.btn--primary:hover { opacity: .85; transform: translateY(-2px); }
+.btn--ghost { border: 1px solid var(--dark-rule-s); color: rgba(240,237,232,.7); }
+.btn--ghost:hover { border-color: var(--dark-ink); color: var(--dark-ink); transform: translateY(-2px); }
+
+.hero-bar {
+  border-top: 1px solid var(--dark-rule);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  max-width: var(--max);
+  width: 100%;
+  margin: 0 auto;
+  position: relative;
+  z-index: 2;
+}
+@media (max-width: 640px) { .hero-bar { grid-template-columns: 1fr 1fr; } }
+.hero-stat {
+  padding: 1.4rem 1.5rem 1.4rem var(--pad);
+  border-right: 1px solid var(--dark-rule);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.hero-stat:last-child { border-right: 0; }
+.hero-stat + .hero-stat { padding-left: 1.5rem; }
+.stat-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--dark-mute);
+}
+.stat-value {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--dark-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  letter-spacing: -0.01em;
+}
+.live-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--signal);
+  box-shadow: 0 0 0 3px var(--signal-soft);
+  flex-shrink: 0;
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+/* =========================================================
+   BRIDGE
+   ========================================================= */
+.bridge {
+  height: clamp(5rem, 10vw, 8rem);
+  background: linear-gradient(to bottom, var(--dark) 0%, var(--cream) 100%);
+}
+
+/* =========================================================
+   CLIENTS STRIP
+   ========================================================= */
+.clients {
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 2rem var(--pad);
+  display: flex;
+  align-items: center;
+  gap: clamp(1.5rem, 4vw, 4rem);
+  overflow: hidden;
+  flex-wrap: wrap;
+}
+.clients-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding-right: clamp(1rem, 3vw, 2.5rem);
+  border-right: 1px solid var(--rule);
+}
+.clients-logos {
+  display: flex;
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: center;
+  flex-wrap: wrap;
+}
+.client-name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: clamp(0.8rem, 1.8vw, 1.05rem);
+  letter-spacing: -0.01em;
+  color: var(--ink-mute);
+  transition: color .25s ease;
+  white-space: nowrap;
+}
+.client-name:hover { color: var(--ink); }
+
+/* =========================================================
+   MANIFESTO
+   ========================================================= */
+.manifesto {
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  background: var(--cream-deep);
+  overflow: hidden;
+}
+.manifesto-inner {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 3.5rem) var(--pad);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+}
+@media (min-width: 900px) {
+  .manifesto-inner { grid-template-columns: repeat(3, 1fr); gap: 3rem; }
+}
+.principle {
+  position: relative;
+  padding-top: 1.4rem;
+  border-top: 1px solid var(--ink);
+}
+.principle-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--ink-mute);
+  position: absolute;
+  top: 1.4rem; right: 0;
+}
+.principle h3 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(1.9rem, 3.5vw, 2.6rem);
+  line-height: 1;
+  letter-spacing: -0.03em;
+  margin-bottom: 1rem;
+}
+.principle h3 em { font-style: normal; color: var(--cobalt); font-weight: 300; }
+.principle p { font-size: 0.95rem; color: var(--ink-soft); max-width: 32ch; }
+
+/* =========================================================
+   SECTION SCAFFOLDING
+   ========================================================= */
+.section {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 9vw, 7rem) var(--pad);
+}
+.section-head {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  margin-bottom: clamp(3rem, 6vw, 5rem);
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--rule);
+  align-items: end;
+}
+@media (min-width: 900px) {
+  .section-head { grid-template-columns: auto 1fr auto; gap: 3rem; }
+}
+.section-head .label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-mute);
+}
+.section-head h2 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  letter-spacing: -0.04em;
+  line-height: 1;
+  text-wrap: balance;
+}
+.section-head h2 em { font-style: normal; color: var(--cobalt); font-weight: 300; }
+.section-head .aside {
+  font-size: 0.9rem;
+  max-width: 26ch;
+  color: var(--ink-mute);
+  align-self: end;
+}
+
+/* =========================================================
+   CAPABILITIES
+   ========================================================= */
+.capabilities {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+}
+@media (min-width: 720px) { .capabilities { grid-template-columns: 1fr 1fr; } }
+@media (min-width: 1100px) { .capabilities { grid-template-columns: repeat(4, 1fr); } }
+
+.cap {
+  background: var(--cream);
+  padding: 2rem 1.8rem 2.5rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  min-height: 320px;
+  transition: background .35s ease, color .35s ease;
+}
+.cap:hover { background: var(--ink); color: var(--cream); }
+.cap:hover .cap-num,
+.cap:hover .cap-desc { color: color-mix(in srgb, var(--cream) 75%, transparent); }
+.cap:hover .cap-arrow { transform: translate(6px, -6px); color: var(--signal); }
+
+.cap-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  color: var(--ink-mute);
+  transition: color .35s ease;
+}
+.cap h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.5rem;
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  margin-top: auto;
+}
+.cap-desc {
+  font-size: 0.92rem;
+  color: var(--ink-soft);
+  transition: color .35s ease;
+  max-width: 30ch;
+}
+.cap-arrow {
+  position: absolute;
+  top: 1.8rem; right: 1.8rem;
+  width: 20px; height: 20px;
+  color: var(--ink-mute);
+  transition: transform .35s cubic-bezier(.2,.7,.2,1), color .35s ease;
+}
+
+/* =========================================================
+   WORK
+   ========================================================= */
+.work {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+}
+@media (min-width: 960px) { .work { grid-template-columns: 1fr 1fr; gap: 2rem; } }
+
+.case { display: flex; flex-direction: column; gap: 1.5rem; }
+.case-frame {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--ink);
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  border: 1px solid var(--rule);
+  transition: transform .5s cubic-bezier(.2,.7,.2,1);
+}
+.case:hover .case-frame { transform: translateY(-6px); }
+.case-frame--carrier { background: linear-gradient(155deg, #0b153f 0%, #0a0908 60%); }
+.case-frame--sku     { background: linear-gradient(155deg, #1a1816 0%, #0a0908 70%); }
+
+.window-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: color-mix(in srgb, var(--cream) 50%, transparent);
+}
+.window-bar .dots { display: flex; gap: 5px; }
+.window-bar .dots span { width: 9px; height: 9px; border-radius: 50%; background: color-mix(in srgb, var(--cream) 18%, transparent); }
+.window-bar .url { margin-left: 0.9rem; padding: 0.2rem 0.65rem; background: color-mix(in srgb, var(--cream) 8%, transparent); border-radius: 999px; letter-spacing: 0.04em; }
+
+.checkout {
+  flex: 1;
+  background: var(--cream);
+  border-radius: 4px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  color: var(--ink);
+}
+.checkout-title {
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.checkout-title small {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.rate {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.55rem 0.7rem;
+  background: var(--cream-deep);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.rate--active { background: var(--ink); color: var(--cream); outline: 2px solid var(--cobalt); outline-offset: -2px; }
+.rate strong { font-weight: 500; letter-spacing: 0.02em; }
+.rate-eta { color: var(--ink-mute); font-size: 9px; }
+.rate--active .rate-eta { color: color-mix(in srgb, var(--cream) 60%, transparent); }
+.rate-price { font-family: var(--font-display); font-size: 0.95rem; font-weight: 600; letter-spacing: -0.02em; }
+
+.dash {
+  flex: 1;
+  background: var(--cream);
+  border-radius: 4px;
+  padding: 0.8rem;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 0.55rem;
+  color: var(--ink);
+}
+.dash-head { display: flex; justify-content: space-between; align-items: baseline; font-family: var(--font-display); font-size: 0.85rem; font-weight: 600; }
+.dash-head small { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-mute); }
+.dash-table { display: grid; grid-template-columns: 1fr 0.6fr 0.5fr 0.5fr; gap: 0.3rem 0.6rem; font-family: var(--font-mono); font-size: 9.5px; align-content: start; }
+.dash-table .th { font-family: var(--font-mono); letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-mute); font-size: 8.5px; padding-bottom: 0.4rem; border-bottom: 1px solid var(--rule); }
+.dash-table .td { padding: 0.32rem 0; border-bottom: 1px solid var(--rule); }
+.pill { display: inline-block; padding: 1px 6px; border-radius: 999px; font-size: 8px; letter-spacing: 0.04em; }
+.pill--live  { background: color-mix(in srgb, var(--signal) 40%, var(--cream)); color: var(--ink); }
+.pill--draft { background: var(--cream-deep); color: var(--ink-mute); }
+
+.case-meta { display: grid; grid-template-columns: auto 1fr; gap: 0.4rem 1rem; align-items: baseline; }
+.case-status { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-mute); display: inline-flex; align-items: center; gap: .45rem; }
+.case-status .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--signal); box-shadow: 0 0 0 3px color-mix(in srgb, var(--signal) 35%, transparent); }
+.case-name { font-family: var(--font-display); font-weight: 600; font-size: 1.65rem; letter-spacing: -0.03em; line-height: 1; grid-column: 1 / -1; }
+.case-desc { color: var(--ink-soft); font-size: 0.95rem; max-width: 50ch; grid-column: 1 / -1; }
+.case-link {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: .55rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--ink);
+  width: fit-content;
+  grid-column: 1 / -1;
+  transition: gap .25s ease, color .25s ease, border-color .25s ease;
+}
+.case-link:hover { gap: .85rem; color: var(--cobalt); border-color: var(--cobalt); }
+
+/* =========================================================
+   PROCESS — dark section
+   ========================================================= */
+.process-section {
+  background: var(--ink);
+  color: var(--cream);
+  position: relative;
+  overflow: hidden;
+}
+.process-section::after {
+  content: "";
+  position: absolute;
+  right: -10%; top: -20%;
+  width: 50vw; height: 50vw;
+  border-radius: 50%;
+  background: radial-gradient(circle, color-mix(in srgb, var(--cobalt) 30%, transparent), transparent 65%);
+  pointer-events: none;
+}
+.process-inner {
+  position: relative; z-index: 2;
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 9vw, 7rem) var(--pad);
+}
+.process-inner .section-head h2 { color: var(--cream); }
+.process-inner .section-head .label { color: color-mix(in srgb, var(--cream) 55%, transparent); }
+.process-inner .section-head .aside { color: color-mix(in srgb, var(--cream) 60%, transparent); }
+.process-inner .section-head { border-color: color-mix(in srgb, var(--cream) 15%, transparent); }
+
+.timeline {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: color-mix(in srgb, var(--cream) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--cream) 12%, transparent);
+}
+@media (min-width: 820px) { .timeline { grid-template-columns: repeat(4, 1fr); } }
+
+.step { background: var(--ink); padding: 2rem 1.8rem 2.4rem; display: flex; flex-direction: column; gap: 0.8rem; min-height: 240px; }
+.step-num { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; color: color-mix(in srgb, var(--cream) 45%, transparent); }
+.step h4 { font-family: var(--font-display); font-weight: 600; font-size: 1.5rem; letter-spacing: -0.025em; line-height: 1.05; color: var(--cream); }
+.step h4 em { color: var(--signal); font-style: normal; font-weight: 300; }
+.step p { font-size: 0.9rem; color: color-mix(in srgb, var(--cream) 65%, transparent); max-width: 30ch; margin-top: auto; }
+
+/* =========================================================
+   PULL QUOTE
+   ========================================================= */
+.pullquote {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 10vw, 8rem) var(--pad);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+}
+@media (min-width: 900px) {
+  .pullquote { grid-template-columns: minmax(0,1fr) 18rem; gap: 4rem; align-items: end; }
+}
+.pullquote blockquote {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(1.8rem, 4.5vw, 3.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  text-wrap: balance;
+}
+.pullquote blockquote em { font-style: normal; color: var(--cobalt); font-weight: 700; }
+.attribution { border-top: 1px solid var(--ink); padding-top: 1.2rem; display: flex; flex-direction: column; gap: 0.3rem; }
+.attribution .name { font-family: var(--font-display); font-weight: 600; font-size: 1rem; letter-spacing: -0.01em; }
+.attribution .role { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-mute); }
+.attribution .others { margin-top: 0.9rem; display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.85rem; color: var(--ink-soft); }
+.attribution .others .o { display: flex; justify-content: space-between; gap: 1rem; border-bottom: 1px dashed var(--rule); padding-bottom: 0.3rem; }
+.attribution .others .o span:last-child { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-mute); }
+
+/* =========================================================
+   INSIGHTS SECTION (homepage preview)
+   ========================================================= */
+.insights-preview {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(4rem, 8vw, 6rem) var(--pad);
+  border-top: 1px solid var(--rule);
+}
+.insights-section-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.insights-section-heading {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  letter-spacing: -0.04em;
+  line-height: 1;
+  margin-top: 0.8rem;
+  margin-bottom: 3rem;
+  text-wrap: balance;
+}
+.insights-section-heading em { font-style: normal; color: var(--cobalt); font-weight: 300; }
+.insights-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+@media (min-width: 760px) { .insights-grid { grid-template-columns: repeat(3, 1fr); } }
+.insight-card {
+  padding: 2rem 0;
+  border-top: 1px solid var(--rule);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  color: var(--ink);
+}
+@media (min-width: 760px) {
+  .insight-card { padding: 0 2rem 0 0; border-top: none; border-left: 1px solid var(--rule); }
+  .insight-card:first-child { padding-left: 0; border-left: none; }
+}
+.insight-cat { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--cobalt); }
+.insight-title { font-family: var(--font-display); font-weight: 600; font-size: clamp(1.05rem, 2vw, 1.25rem); line-height: 1.2; letter-spacing: -0.02em; color: var(--ink); transition: color .25s ease; }
+.insight-card:hover .insight-title { color: var(--cobalt); }
+.insight-excerpt { font-size: 0.875rem; line-height: 1.6; color: var(--ink-soft); flex: 1; }
+.insight-meta { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-mute); margin-top: 0.4rem; }
+.insights-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 2.5rem;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--cobalt);
+  border-bottom: 1px solid var(--cobalt);
+  padding-bottom: 2px;
+  transition: opacity .2s ease;
+}
+.insights-all:hover { opacity: 0.7; }
+
+/* =========================================================
+   CTA / CONTACT
+   ========================================================= */
+.cta-section {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 0 var(--pad) clamp(4rem, 8vw, 6rem);
+}
+.cta-card {
+  position: relative;
+  overflow: hidden;
+  background: var(--ink);
+  color: var(--cream);
+  border-radius: 8px;
+  padding: clamp(2.5rem, 7vw, 5rem) clamp(2rem, 6vw, 5rem);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+}
+@media (min-width: 900px) { .cta-card { grid-template-columns: 1fr 1fr; gap: 4rem; align-items: start; } }
+.cta-card::before {
+  content: "";
+  position: absolute;
+  left: -10%; bottom: -60%;
+  width: 60vw; height: 60vw;
+  background: radial-gradient(circle, color-mix(in srgb, var(--cobalt) 70%, transparent), transparent 60%);
+  pointer-events: none;
+  filter: blur(20px);
+}
+.cta-card > * { position: relative; z-index: 2; }
+.cta-card h2 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  text-wrap: balance;
+}
+.cta-card h2 em { font-style: normal; color: var(--signal); font-weight: 300; }
+.cta-lead { color: color-mix(in srgb, var(--cream) 75%, transparent); max-width: 36ch; margin-top: 1.5rem; }
+.cta-direct {
+  margin-top: 2rem;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--cream) 50%, transparent);
+}
+.cta-direct a { display: inline; color: color-mix(in srgb, var(--cream) 75%, transparent); transition: color .2s ease; }
+.cta-direct a:hover { color: var(--signal); }
+
+.cta-form { display: flex; flex-direction: column; gap: 1rem; }
+.cta-field { display: flex; flex-direction: column; gap: 0.35rem; }
+.cta-field label { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: color-mix(in srgb, var(--cream) 50%, transparent); }
+.cta-field input,
+.cta-field textarea {
+  background: color-mix(in srgb, var(--cream) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--cream) 20%, transparent);
+  border-radius: 4px;
+  padding: 0.75rem 1rem;
+  color: var(--cream);
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  width: 100%;
+  transition: border-color .2s ease;
+  outline: none;
+}
+.cta-field input:focus,
+.cta-field textarea:focus { border-color: var(--cobalt); }
+.cta-field input::placeholder,
+.cta-field textarea::placeholder { color: color-mix(in srgb, var(--cream) 30%, transparent); }
+.cta-field textarea { resize: vertical; min-height: 100px; }
+.cta-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.4rem;
+  background: var(--cream);
+  color: var(--ink);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: none;
+  cursor: pointer;
+  width: 100%;
+  transition: transform .25s ease, background .25s ease;
+  margin-top: 0.5rem;
+}
+.cta-submit:hover { background: var(--signal); transform: translateY(-2px); }
+.cta-success {
+  display: none;
+  padding: 1.5rem;
+  background: color-mix(in srgb, var(--signal) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--signal) 40%, transparent);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: var(--signal);
+  text-transform: uppercase;
+}
+
+/* =========================================================
+   FOOTER
+   ========================================================= */
+.site-footer {
+  border-top: 1px solid var(--rule);
+  padding: 2.5rem var(--pad);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  max-width: var(--max);
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
+}
+.site-footer a:hover { color: var(--ink); }
+.footer-flag { display: inline-flex; align-items: center; gap: .4rem; color: var(--ink-mute); }
+.footer-social { display: flex; align-items: center; gap: 1.2rem; }
+.footer-social a { display: inline-flex; align-items: center; gap: .4rem; color: var(--ink-mute); transition: color .25s ease; }
+.footer-social a:hover { color: var(--ink); }
+
+/* =========================================================
+   REVEAL ANIMATIONS
+   ========================================================= */
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity .9s cubic-bezier(.2,.7,.2,1), transform .9s cubic-bezier(.2,.7,.2,1);
+}
+.reveal.in { opacity: 1; transform: translateY(0); }
+.reveal:nth-child(2) { transition-delay: 0.08s; }
+.reveal:nth-child(3) { transition-delay: 0.16s; }
+.reveal:nth-child(4) { transition-delay: 0.24s; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
+  .reveal { opacity: 1; transform: none; }
+}
+
+/* =========================================================
+   INSIGHTS LIST PAGE
+   ========================================================= */
+.insights-page {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: clamp(6rem, 12vw, 9rem) var(--pad) clamp(4rem, 8vw, 6rem);
+}
+.insights-page-heading {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  letter-spacing: -0.04em;
+  line-height: 0.95;
+  margin-bottom: 1rem;
+}
+.insights-page-heading em { font-style: normal; color: var(--cobalt); font-weight: 300; }
+.insights-page-sub { font-size: 1.05rem; color: var(--ink-soft); max-width: 48ch; margin-bottom: clamp(3rem, 6vw, 5rem); }
+.insights-post-list { display: flex; flex-direction: column; gap: 0; }
+.insights-post {
+  padding: 2.5rem 0;
+  border-top: 1px solid var(--rule);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.insights-post:last-child { border-bottom: 1px solid var(--rule); }
+.insights-post-meta { display: flex; align-items: center; gap: 0.75rem; }
+.insights-post-cat { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--cobalt); }
+.insights-post-date { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-mute); }
+.insights-post-title { font-family: var(--font-display); font-weight: 700; font-size: clamp(1.4rem, 3vw, 1.9rem); letter-spacing: -0.03em; line-height: 1.1; color: var(--ink); transition: color .25s ease; }
+.insights-post-title:hover { color: var(--cobalt); }
+.insights-post-excerpt { font-size: 0.95rem; color: var(--ink-soft); max-width: 60ch; line-height: 1.65; }
+.insights-read-more { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; display: inline-flex; align-items: center; gap: 0.5rem; color: var(--cobalt); border-bottom: 1px solid var(--cobalt); padding-bottom: 2px; width: fit-content; transition: opacity .2s ease; }
+.insights-read-more:hover { opacity: 0.7; }
+
+/* =========================================================
+   INSIGHT POST PAGE
+   ========================================================= */
+.post-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: clamp(6rem, 12vw, 9rem) var(--pad) clamp(4rem, 8vw, 6rem);
+}
+.post-back { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; display: inline-flex; align-items: center; gap: 0.5rem; color: var(--ink-mute); margin-bottom: 3rem; transition: color .2s ease; }
+.post-back:hover { color: var(--ink); }
+.post-meta { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+.post-cat { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--cobalt); }
+.post-date { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-mute); }
+.post-author { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-mute); }
+.post-title { font-family: var(--font-display); font-weight: 700; font-size: clamp(2rem, 5vw, 3.2rem); letter-spacing: -0.04em; line-height: 1; margin-bottom: 1rem; }
+.post-excerpt { font-size: 1.1rem; color: var(--ink-soft); line-height: 1.65; margin-bottom: 3rem; max-width: 54ch; }
+.post-divider { border: none; border-top: 1px solid var(--rule); margin: 3rem 0; }
+.post-footer { display: flex; align-items: center; justify-content: space-between; margin-top: 3rem; }
+.post-footer-link { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; display: inline-flex; align-items: center; gap: 0.5rem; color: var(--cobalt); border-bottom: 1px solid var(--cobalt); padding-bottom: 2px; transition: opacity .2s ease; }
+.post-footer-link:hover { opacity: 0.7; }
+
+/* Prose overrides for cream theme */
+.prose-hybrid {
+  font-family: var(--font-body);
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--ink-soft);
+}
+.prose-hybrid h2, .prose-hybrid h3 { font-family: var(--font-display); font-weight: 700; letter-spacing: -0.03em; color: var(--ink); }
+.prose-hybrid h2 { font-size: clamp(1.5rem, 3vw, 2rem); margin-top: 3rem; margin-bottom: 1rem; }
+.prose-hybrid h3 { font-size: 1.25rem; margin-top: 2rem; margin-bottom: 0.75rem; }
+.prose-hybrid p { margin-bottom: 1.5rem; }
+.prose-hybrid a { color: var(--cobalt); border-bottom: 1px solid color-mix(in srgb, var(--cobalt) 40%, transparent); transition: border-color .2s ease; }
+.prose-hybrid a:hover { border-color: var(--cobalt); }
+.prose-hybrid strong { font-weight: 600; color: var(--ink); }
+.prose-hybrid hr { border: none; border-top: 1px solid var(--rule); margin: 3rem 0; }
+.prose-hybrid ul, .prose-hybrid ol { padding-left: 1.5rem; margin-bottom: 1.5rem; }
+.prose-hybrid li { margin-bottom: 0.5rem; }
+.prose-hybrid code { font-family: var(--font-mono); font-size: 0.88em; background: var(--cream-deep); padding: 0.15em 0.4em; border-radius: 3px; }
+.prose-hybrid pre { background: var(--ink); color: var(--dark-ink); padding: 1.5rem; border-radius: 6px; overflow-x: auto; margin-bottom: 1.5rem; }
+.prose-hybrid pre code { background: none; padding: 0; font-size: 0.9rem; }
+.prose-hybrid blockquote { border-left: 3px solid var(--cobalt); padding-left: 1.5rem; margin: 2rem 0; color: var(--ink-mute); font-style: italic; }

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -1,0 +1,124 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getAllInsights, getInsightBySlug, formatDate } from "@/lib/insights";
+import type { Metadata } from "next";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  return getAllInsights().map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getInsightBySlug(slug);
+  if (!post) return {};
+  return {
+    title: `${post.title} — NITSOF`,
+    description: post.excerpt,
+  };
+}
+
+export default async function InsightPost({ params }: Props) {
+  const { slug } = await params;
+  const post = getInsightBySlug(slug);
+  if (!post) notFound();
+
+  return (
+    <div className="relative z-10 mx-auto max-w-screen-xl px-4 py-24 lg:px-8">
+      <div className="mx-auto max-w-2xl">
+        <Link
+          href="/insights"
+          className="mb-10 inline-flex items-center gap-2 text-sm text-gray-500 transition hover:text-gray-300"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <line x1="19" y1="12" x2="5" y2="12" />
+            <polyline points="12 5 5 12 12 19" />
+          </svg>
+          All insights
+        </Link>
+
+        <div className="flex items-center gap-4">
+          <span className="text-xs font-medium uppercase tracking-widest text-blue-400">
+            {post.category}
+          </span>
+          <span className="text-xs text-gray-600">·</span>
+          <time className="text-xs text-gray-500" dateTime={post.date}>
+            {formatDate(post.date)}
+          </time>
+          <span className="text-xs text-gray-600">·</span>
+          <span className="text-xs text-gray-500">{post.author}</span>
+        </div>
+
+        <h1 className="mt-4 text-3xl font-bold leading-tight text-white sm:text-4xl">
+          {post.title}
+        </h1>
+        <p className="mt-4 text-lg text-gray-400">{post.excerpt}</p>
+
+        <hr className="my-10 border-gray-800" />
+
+        <div
+          className="prose prose-invert prose-lg max-w-none prose-headings:font-bold prose-headings:text-white prose-p:text-gray-300 prose-a:text-blue-400 prose-strong:text-white prose-hr:border-gray-800"
+          dangerouslySetInnerHTML={{ __html: post.content }}
+        />
+
+        <hr className="my-12 border-gray-800" />
+
+        <div className="flex items-center justify-between">
+          <Link
+            href="/insights"
+            className="inline-flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-blue-300"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="19" y1="12" x2="5" y2="12" />
+              <polyline points="12 5 5 12 12 19" />
+            </svg>
+            All insights
+          </Link>
+          <a
+            href="mailto:hello@nitsof.com"
+            className="inline-flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-blue-300"
+          >
+            Get in touch
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="5" y1="12" x2="19" y2="12" />
+              <polyline points="12 5 19 12 12 19" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -27,97 +27,76 @@ export default async function InsightPost({ params }: Props) {
   if (!post) notFound();
 
   return (
-    <div className="relative z-10 mx-auto max-w-screen-xl px-4 py-24 lg:px-8">
-      <div className="mx-auto max-w-2xl">
-        <Link
-          href="/insights"
-          className="mb-10 inline-flex items-center gap-2 text-sm text-gray-500 transition hover:text-gray-300"
+    <div className="post-page">
+      <Link href="/insights" className="post-back">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         >
+          <path d="M19 12H5M11 5l-7 7 7 7" />
+        </svg>
+        All insights
+      </Link>
+
+      <div className="post-meta">
+        <span className="post-cat">{post.category}</span>
+        <span style={{ color: "var(--ink-mute)", fontSize: "10px" }}>&middot;</span>
+        <time className="post-date" dateTime={post.date}>
+          {formatDate(post.date)}
+        </time>
+        <span style={{ color: "var(--ink-mute)", fontSize: "10px" }}>&middot;</span>
+        <span className="post-author">{post.author}</span>
+      </div>
+
+      <h1 className="post-title">{post.title}</h1>
+      <p className="post-excerpt">{post.excerpt}</p>
+
+      <hr className="post-divider" />
+
+      <div
+        className="prose-hybrid"
+        dangerouslySetInnerHTML={{ __html: post.content }}
+      />
+
+      <hr className="post-divider" />
+
+      <div className="post-footer">
+        <Link href="/insights" className="post-footer-link">
           <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
+            width="12"
+            height="12"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
-            strokeWidth="2"
+            strokeWidth="2.2"
             strokeLinecap="round"
             strokeLinejoin="round"
           >
-            <line x1="19" y1="12" x2="5" y2="12" />
-            <polyline points="12 5 5 12 12 19" />
+            <path d="M19 12H5M11 5l-7 7 7 7" />
           </svg>
           All insights
         </Link>
-
-        <div className="flex items-center gap-4">
-          <span className="text-xs font-medium uppercase tracking-widest text-blue-400">
-            {post.category}
-          </span>
-          <span className="text-xs text-gray-600">·</span>
-          <time className="text-xs text-gray-500" dateTime={post.date}>
-            {formatDate(post.date)}
-          </time>
-          <span className="text-xs text-gray-600">·</span>
-          <span className="text-xs text-gray-500">{post.author}</span>
-        </div>
-
-        <h1 className="mt-4 text-3xl font-bold leading-tight text-white sm:text-4xl">
-          {post.title}
-        </h1>
-        <p className="mt-4 text-lg text-gray-400">{post.excerpt}</p>
-
-        <hr className="my-10 border-gray-800" />
-
-        <div
-          className="prose prose-invert prose-lg max-w-none prose-headings:font-bold prose-headings:text-white prose-p:text-gray-300 prose-a:text-blue-400 prose-strong:text-white prose-hr:border-gray-800"
-          dangerouslySetInnerHTML={{ __html: post.content }}
-        />
-
-        <hr className="my-12 border-gray-800" />
-
-        <div className="flex items-center justify-between">
-          <Link
-            href="/insights"
-            className="inline-flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-blue-300"
+        <a href="mailto:hello@nitsof.com" className="post-footer-link">
+          Get in touch
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <line x1="19" y1="12" x2="5" y2="12" />
-              <polyline points="12 5 5 12 12 19" />
-            </svg>
-            All insights
-          </Link>
-          <a
-            href="mailto:hello@nitsof.com"
-            className="inline-flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-blue-300"
-          >
-            Get in touch
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <line x1="5" y1="12" x2="19" y2="12" />
-              <polyline points="12 5 19 12 12 19" />
-            </svg>
-          </a>
-        </div>
+            <path d="M5 12h14M13 5l7 7-7 7" />
+          </svg>
+        </a>
       </div>
     </div>
   );

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { getAllInsights, formatDate } from "@/lib/insights";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Insights — NITSOF",
+  description:
+    "Thinking out loud on software delivery, AI-native development, and building products that last.",
+};
+
+export default function InsightsPage() {
+  const posts = getAllInsights();
+
+  return (
+    <div className="relative z-10 mx-auto max-w-screen-xl px-4 py-24 lg:px-8">
+      <div className="max-w-2xl">
+        <p className="text-sm font-medium uppercase tracking-widest text-blue-400">
+          Insights
+        </p>
+        <h1 className="mt-3 text-4xl font-bold text-white sm:text-5xl">
+          Thinking out loud
+        </h1>
+        <p className="mt-4 text-lg text-gray-400">
+          Notes on software delivery, AI-native development, and building
+          products that last.
+        </p>
+      </div>
+
+      <div className="mt-16 divide-y divide-gray-800">
+        {posts.map((post) => (
+          <article key={post.slug} className="py-10 first:pt-0">
+            <div className="flex items-center gap-4">
+              <span className="text-xs font-medium uppercase tracking-widest text-blue-400">
+                {post.category}
+              </span>
+              <span className="text-xs text-gray-600">·</span>
+              <time className="text-xs text-gray-500" dateTime={post.date}>
+                {formatDate(post.date)}
+              </time>
+            </div>
+            <h2 className="mt-3 text-2xl font-bold text-white">
+              <Link
+                href={`/insights/${post.slug}`}
+                className="transition hover:text-blue-400"
+              >
+                {post.title}
+              </Link>
+            </h2>
+            <p className="mt-3 text-gray-400">{post.excerpt}</p>
+            <Link
+              href={`/insights/${post.slug}`}
+              className="mt-5 inline-flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-blue-300"
+            >
+              Read more
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="5" y1="12" x2="19" y2="12" />
+                <polyline points="12 5 19 12 12 19" />
+              </svg>
+            </Link>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -12,59 +12,57 @@ export default function InsightsPage() {
   const posts = getAllInsights();
 
   return (
-    <div className="relative z-10 mx-auto max-w-screen-xl px-4 py-24 lg:px-8">
-      <div className="max-w-2xl">
-        <p className="text-sm font-medium uppercase tracking-widest text-blue-400">
-          Insights
-        </p>
-        <h1 className="mt-3 text-4xl font-bold text-white sm:text-5xl">
-          Thinking out loud
-        </h1>
-        <p className="mt-4 text-lg text-gray-400">
-          Notes on software delivery, AI-native development, and building
-          products that last.
-        </p>
-      </div>
+    <div className="insights-page">
+      <p
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "11px",
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          color: "var(--cobalt)",
+          marginBottom: "0.75rem",
+        }}
+      >
+        &sect; Insights
+      </p>
+      <h1 className="insights-page-heading">
+        Thinking out <em>loud</em>.
+      </h1>
+      <p className="insights-page-sub">
+        Notes on software delivery, AI-native development, and building
+        products that last.
+      </p>
 
-      <div className="mt-16 divide-y divide-gray-800">
+      <div className="insights-post-list">
         {posts.map((post) => (
-          <article key={post.slug} className="py-10 first:pt-0">
-            <div className="flex items-center gap-4">
-              <span className="text-xs font-medium uppercase tracking-widest text-blue-400">
-                {post.category}
-              </span>
-              <span className="text-xs text-gray-600">·</span>
-              <time className="text-xs text-gray-500" dateTime={post.date}>
+          <article key={post.slug} className="insights-post">
+            <div className="insights-post-meta">
+              <span className="insights-post-cat">{post.category}</span>
+              <span style={{ color: "var(--ink-mute)", fontSize: "10px" }}>&middot;</span>
+              <time className="insights-post-date" dateTime={post.date}>
                 {formatDate(post.date)}
               </time>
             </div>
-            <h2 className="mt-3 text-2xl font-bold text-white">
-              <Link
-                href={`/insights/${post.slug}`}
-                className="transition hover:text-blue-400"
-              >
-                {post.title}
-              </Link>
-            </h2>
-            <p className="mt-3 text-gray-400">{post.excerpt}</p>
             <Link
               href={`/insights/${post.slug}`}
-              className="mt-5 inline-flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-blue-300"
+              className="insights-post-title"
             >
+              {post.title}
+            </Link>
+            <p className="insights-post-excerpt">{post.excerpt}</p>
+            <Link href={`/insights/${post.slug}`} className="insights-read-more">
               Read more
               <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="16"
-                height="16"
+                width="12"
+                height="12"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
-                strokeWidth="2"
+                strokeWidth="2.2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
               >
-                <line x1="5" y1="12" x2="19" y2="12" />
-                <polyline points="12 5 19 12 12 19" />
+                <path d="M5 12h14M13 5l7 7-7 7" />
               </svg>
             </Link>
           </article>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,23 +1,32 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import PageAnimations from "@/components/PageAnimations";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+export const viewport: Viewport = {
+  themeColor: "#07080B",
+};
 
 export const metadata: Metadata = {
-  title: "NITSOF – AI Software Delivery for Businesses",
+  title: "NITSOF — Software, shipped at the speed of thought.",
   description:
-    "NITSOF helps businesses innovate and ship software faster using AI. See our products and AI-powered delivery in action.",
+    "An AI-native software studio. Four disciplines, one team. Australia · Worldwide.",
+  openGraph: {
+    type: "website",
+    url: "https://nitsof.com",
+    title: "NITSOF — Software, shipped at the speed of thought.",
+    description:
+      "An AI-native software studio. Currently open for Q3 engagements. Australia · Worldwide.",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "NITSOF — Software, shipped at the speed of thought.",
+    description: "An AI-native software studio. Australia · Worldwide.",
+  },
+  icons: {
+    icon: "/favicon.svg",
+  },
 };
 
 export default function RootLayout({
@@ -26,19 +35,28 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html
-      lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} bg-gray-900`}
-    >
-      <body className="flex min-h-screen flex-col text-gray-200">
+    <html lang="en">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap"
+        />
+        <link rel="preconnect" href="https://api.fontshare.com" crossOrigin="" />
+        <link rel="preconnect" href="https://cdn.fontshare.com" crossOrigin="" />
+        {/* General Sans + Switzer via FontShare — not available through next/font */}
+        <link
+          rel="stylesheet"
+          href="https://api.fontshare.com/v2/css?f[]=general-sans@300,400,500,600,700&f[]=switzer@300,400,500,600,700&display=swap"
+        />
+      </head>
+      <body>
+        <div id="scroll-progress" aria-hidden="true" />
+        <div className="grain-overlay" aria-hidden="true" />
+        <PageAnimations />
         <Header />
-        <main
-          className="relative flex-grow bg-cover bg-center bg-no-repeat"
-          style={{ backgroundImage: "url('/images/hero-background.jpg')" }}
-        >
-          <div className="absolute inset-0 bg-black/75 sm:bg-transparent sm:from-black/95 sm:to-black/25 sm:bg-gradient-to-r" />
-          {children}
-        </main>
+        <main>{children}</main>
         <Footer />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,197 +1,519 @@
 import Link from "next/link";
+import ContactForm from "@/components/ContactForm";
+import { getAllInsights } from "@/lib/insights";
 
-/** Renders a single service capability card with a title and description. */
-const CapabilityCard = ({ title, description }: { title: string; description: string }) => (
-  <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-6 transition-all hover:border-blue-500/50 hover:bg-gray-900">
-    <h3 className="text-lg font-bold text-white">{title}</h3>
-    <p className="mt-2 text-sm text-gray-400">{description}</p>
-  </div>
+const ArrowRight = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M5 12h14M13 5l7 7-7 7" />
+  </svg>
 );
 
-/** Renders a client testimonial card with a quote and attribution. */
-const TestimonialCard = ({ quote, attribution }: { quote: string; attribution: string }) => (
-  <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-6">
-    <p className="text-gray-300 italic">&ldquo;{quote}&rdquo;</p>
-    <p className="mt-4 text-sm font-medium text-blue-400">{attribution}</p>
-  </div>
+const CapArrow = () => (
+  <svg
+    className="cap-arrow"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+  >
+    <path d="M7 17L17 7M9 7h8v8" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
 );
 
 export default function Home() {
+  const insights = getAllInsights().slice(0, 3);
+
   return (
-    <div className="relative z-10">
-      {/* Hero Section */}
-      <section className="mx-auto flex h-screen min-h-[700px] max-w-screen-xl items-center px-4 py-32 lg:px-8">
-        <div className="max-w-3xl text-left">
-          <h1 className="bg-gradient-to-r from-green-300 via-blue-500 to-purple-600 bg-clip-text text-4xl font-extrabold text-transparent sm:text-6xl">
-            Deliver Software Faster with AI
+    <>
+      {/* TICKER */}
+      <div className="ticker" aria-hidden="true">
+        <div className="ticker-track">
+          <span className="ticker-item ticker-item--live">
+            <span className="ticker-dot" />
+            <strong>Now shipping</strong> &middot; Carrier Rates v2.1 &mdash; live in 240+ stores
+          </span>
+          <span className="ticker-item">
+            <span className="ticker-dot" />
+            AI-augmented delivery &middot; est. 2024
+          </span>
+          <span className="ticker-item">
+            <span className="ticker-dot" />
+            Currently accepting Q3 engagements
+          </span>
+          <span className="ticker-item">
+            <span className="ticker-dot" />
+            Software &harr; thought &middot; velocity 4.2&times;
+          </span>
+          <span className="ticker-item ticker-item--live">
+            <span className="ticker-dot" />
+            <strong>Now shipping</strong> &middot; Carrier Rates v2.1 &mdash; live in 240+ stores
+          </span>
+          <span className="ticker-item">
+            <span className="ticker-dot" />
+            AI-augmented delivery &middot; est. 2024
+          </span>
+          <span className="ticker-item">
+            <span className="ticker-dot" />
+            Currently accepting Q3 engagements
+          </span>
+          <span className="ticker-item">
+            <span className="ticker-dot" />
+            Software &harr; thought &middot; velocity 4.2&times;
+          </span>
+        </div>
+      </div>
+
+      {/* HERO */}
+      <section className="hero" id="hero">
+        <div className="hero-glow" aria-hidden="true" />
+        <div className="hero-glow-2" aria-hidden="true" />
+        <div className="hero-inner">
+          <p className="hero-eyebrow reveal">An AI-native software studio</p>
+          <h1 className="reveal">
+            Software,
+            <br />
+            shipped at the speed
+            <br />
+            of <em>thought</em>.
           </h1>
-
-          <p className="mt-4 max-w-xl text-lg text-gray-300 sm:text-xl/relaxed">
-            NITSOF is an AI specialist firm that helps businesses build, ship, and iterate on software at a pace that wasn&apos;t possible before — from early-stage startups to established enterprises.
-          </p>
-
-          <div className="mt-8 flex flex-wrap gap-4">
-            <Link
-              href="/#portfolio"
-              className="block w-full rounded border border-blue-600 bg-blue-600 px-12 py-3 text-sm font-medium text-white transition hover:bg-transparent hover:text-white focus:outline-none focus:ring active:text-white/75 sm:w-auto"
-            >
-              See Our Work
-            </Link>
-            <Link
-              href="/#about"
-              className="block w-full rounded border border-white px-12 py-3 text-sm font-medium text-white transition hover:bg-white hover:text-gray-900 focus:outline-none focus:ring active:bg-blue-500 sm:w-auto"
-            >
-              Work With Us
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Services / Capabilities Section */}
-      <section id="services" className="mx-auto max-w-screen-xl px-4 py-16 sm:py-24 lg:px-8">
-        <div className="mx-auto max-w-3xl text-center">
-          <h2 className="text-3xl font-bold text-white sm:text-4xl">
-            How We Help You Move Faster
-          </h2>
-          <p className="mt-4 text-gray-400">
-            We put AI at the center of software delivery — not as a gimmick, but as a methodology that cuts time-to-market without cutting quality.
-          </p>
-        </div>
-        <div className="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
-          <CapabilityCard
-            title="AI-Powered Development"
-            description="We use AI throughout the entire build process — from scoping and design to code and QA. The result is faster delivery with fewer blind spots."
-          />
-          <CapabilityCard
-            title="Production-Grade Engineering"
-            description="What we ship runs in production at scale. No demos, no fragile prototypes — real software built to last and grow with your business."
-          />
-          <CapabilityCard
-            title="End-to-End Partnership"
-            description="We stay involved from strategy through deployment and beyond. You're not handed off at launch — we iterate with you as your needs evolve."
-          />
-          <CapabilityCard
-            title="Built for Any Scale"
-            description="Startup or enterprise, 5 people or 500 — our approach adapts to your size, your stack, and the pace you need to move at."
-          />
-        </div>
-      </section>
-
-      {/* Portfolio Section */}
-      <section id="portfolio" className="mx-auto max-w-screen-xl px-4 py-16 sm:py-24 lg:px-8">
-        <div className="mx-auto max-w-3xl text-center">
-          <h2 className="text-3xl font-bold text-white sm:text-4xl">
-            What We&apos;ve Built
-          </h2>
-          <p className="mt-4 text-gray-400">
-            We build our own products and deliver client work — both prove that our approach works in production.
-          </p>
-        </div>
-        <div className="mt-12 grid grid-cols-1 gap-8 md:grid-cols-2">
-          <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-8 transition-all hover:border-blue-500/50 hover:bg-gray-900">
-            <div className="flex items-center gap-3">
-              <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg bg-gray-800 text-blue-400">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4.5 16.5c-2.1 0-3.5-1.4-3.5-3.5s1.4-3.5 3.5-3.5h15c2.1 0 3.5 1.4 3.5 3.5s-1.4 3.5-3.5 3.5h-15Z" /><path d="m8 16-1.5-1.5L8 13" /><path d="M16 8l1.5 1.5L16 11" /></svg>
-              </div>
-              <div>
-                <h3 className="text-xl font-bold text-white">Carrier Rates</h3>
-                <span className="text-xs font-medium text-green-400">Live</span>
-              </div>
-            </div>
-            <p className="mt-4 text-gray-400">
-              Shoppers abandon carts when shipping costs are a surprise. Carrier Rates connects your Shopify store directly to carrier APIs so customers see live, accurate shipping costs at checkout — before they decide to leave. One integration, fewer lost sales.
-            </p>
-            <Link
-              href="/carrier-rates"
-              className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-blue-300"
-            >
-              Explore Carrier Rates
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
-            </Link>
-          </div>
-
-          <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-8 transition-all hover:border-blue-500/50 hover:bg-gray-900">
-            <div className="flex items-center gap-3">
-              <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg bg-gray-800 text-blue-400">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8"/><path d="M12 17v4"/><path d="M7 8h10"/><path d="M7 12h4"/></svg>
-              </div>
-              <div>
-                <h3 className="text-xl font-bold text-white">SKU Manager</h3>
-              </div>
-            </div>
-            <p className="mt-4 text-gray-400">
-              Managing complex product catalogs at scale is harder than it looks. SKU Manager gives operations and merchandising teams the tools to organize, search, and maintain product data without the mess — built for businesses where inventory complexity is a real problem.
-            </p>
-            <a
-              href="https://skumanager.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-blue-300"
-            >
-              Visit skumanager.com
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+          <div className="hero-actions reveal">
+            <a className="btn btn--primary" href="#work">
+              See selected work <ArrowRight />
+            </a>
+            <a className="btn btn--ghost" href="#contact">
+              Begin a project
             </a>
           </div>
         </div>
-      </section>
-
-      {/* About Section */}
-      <section id="about" className="mx-auto max-w-screen-xl px-4 py-16 sm:py-24 lg:px-8">
-        <div className="mx-auto max-w-3xl text-center">
-          <h2 className="text-3xl font-bold text-white sm:text-4xl">
-            Why We Exist
-          </h2>
-          <p className="prose prose-lg prose-invert mx-auto mt-6">
-            Most businesses are moving slower than they should — not because of their people, but because of how software gets built. NITSOF exists to change that. We&apos;re an AI specialist firm that embeds AI throughout the software delivery lifecycle, so our clients build better software faster. Whether you&apos;re a founder racing to ship your next product or a CTO trying to modernize a legacy stack, we bring the expertise and tools to get there.
-          </p>
-        </div>
-      </section>
-
-      {/* Testimonials Section */}
-      <section id="testimonials" className="mx-auto max-w-screen-xl px-4 py-16 sm:py-24 lg:px-8">
-        <div className="mx-auto max-w-3xl text-center">
-          <p className="text-sm font-medium uppercase tracking-widest text-blue-400">
-            Partnering with startups and enterprises to ship faster
-          </p>
-          <h2 className="mt-2 text-3xl font-bold text-white sm:text-4xl">
-            What Our Clients Say
-          </h2>
-        </div>
-        <div className="mt-12 grid grid-cols-1 gap-8 md:grid-cols-3">
-          <TestimonialCard
-            quote="NITSOF cut our expected delivery timeline in half. The AI-first approach isn't a pitch — it's how they actually work."
-            attribution="James Harlow, CTO — Apex Logistics Group"
-          />
-          <TestimonialCard
-            quote="We needed a partner who understood both the technical depth and the business pressure we were under. NITSOF delivered on both."
-            attribution="Priya Mehta, Founder — Stackborn"
-          />
-          <TestimonialCard
-            quote="The quality is enterprise-grade but the speed feels like a startup. That combination is rare."
-            attribution="Daniel Osei, VP of Product — Mercia Health"
-          />
-        </div>
-      </section>
-
-      {/* Footer CTA Section */}
-      <section className="mx-auto max-w-screen-xl px-4 py-16 sm:py-24 lg:px-8">
-        <div className="rounded-xl border border-gray-800 bg-gray-900/50 px-8 py-12 text-center">
-          <h2 className="text-3xl font-bold text-white sm:text-4xl">
-            Ready to build faster?
-          </h2>
-          <p className="mt-4 text-lg text-gray-400">
-            Let&apos;s talk about what AI-powered delivery could mean for your next project.
-          </p>
-          <div className="mt-8">
-            <a
-              href="mailto:hello@nitsof.com"
-              className="inline-block rounded border border-blue-600 bg-blue-600 px-12 py-3 text-sm font-medium text-white transition hover:bg-transparent hover:text-white focus:outline-none focus:ring active:text-white/75"
-            >
-              Get in Touch
-            </a>
+        <div className="hero-bar">
+          <div className="hero-stat">
+            <span className="stat-label">Capacity</span>
+            <span className="stat-value">
+              <span className="live-dot" />
+              Open &middot; Q3 2026
+            </span>
+          </div>
+          <div className="hero-stat">
+            <span className="stat-label">From</span>
+            <span className="stat-value">Australia &middot; Worldwide</span>
+          </div>
+          <div className="hero-stat">
+            <span className="stat-label">Est.</span>
+            <span className="stat-value">2024</span>
+          </div>
+          <div className="hero-stat">
+            <span className="stat-label">Velocity</span>
+            <span className="stat-value">4.2&times; faster delivery</span>
           </div>
         </div>
       </section>
-    </div>
+
+      {/* BRIDGE */}
+      <div className="bridge" aria-hidden="true" />
+
+      {/* CLIENT STRIP */}
+      <div className="clients reveal">
+        <span className="clients-label">Trusted by</span>
+        <div className="clients-logos">
+          <span className="client-name">Apex Logistics</span>
+          <span className="client-name">Stackborn</span>
+          <span className="client-name">Mercia Health</span>
+          <span className="client-name">Nordpath Retail</span>
+          <span className="client-name">LiveCarrierRates</span>
+        </div>
+      </div>
+
+      {/* MANIFESTO */}
+      <section className="manifesto">
+        <div className="manifesto-inner">
+          <div className="principle reveal">
+            <span className="principle-num">01 &mdash; Principle</span>
+            <h3>
+              Simplicity is <em>the</em> feature.
+            </h3>
+            <p>
+              We strip out everything that doesn&apos;t earn its place. Fewer
+              dependencies, fewer screens, fewer meetings. The shortest path from
+              problem to production.
+            </p>
+          </div>
+          <div className="principle reveal">
+            <span className="principle-num">02 &mdash; Principle</span>
+            <h3>
+              Confidence in <em>craft</em>.
+            </h3>
+            <p>
+              We don&apos;t ship demos. We ship software our clients depend on to run
+              their business &mdash; measured in uptime, revenue, and the quality of a
+              sleepless night avoided.
+            </p>
+          </div>
+          <div className="principle reveal">
+            <span className="principle-num">03 &mdash; Principle</span>
+            <h3>
+              Building the <em>future</em>, now.
+            </h3>
+            <p>
+              AI sits inside our delivery loop, not as a feature on a slide. The
+              pace this enables is the only thing that lets a four-person team
+              out-ship a fifty-person one.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* CAPABILITIES */}
+      <section className="section" id="capabilities">
+        <div className="section-head">
+          <span className="label">&sect; Capabilities</span>
+          <h2>
+            Four disciplines, <em>one</em> studio.
+          </h2>
+          <p className="aside">
+            Each engagement is led by a senior engineer who stays through
+            delivery. No handoffs, no juniors learning on your time.
+          </p>
+        </div>
+        <div className="capabilities">
+          <article className="cap reveal">
+            <span className="cap-num">01 / Strategy</span>
+            <CapArrow />
+            <h3>Product archaeology.</h3>
+            <p className="cap-desc">
+              We map what&apos;s actually there before adding anything new &mdash; most
+              teams already have 70% of what they need, just badly arranged.
+            </p>
+          </article>
+          <article className="cap reveal">
+            <span className="cap-num">02 / Build</span>
+            <CapArrow />
+            <h3>AI-augmented engineering.</h3>
+            <p className="cap-desc">
+              Senior engineers paired with AI throughout &mdash; design, code, review,
+              QA. Same craft, 3&ndash;5&times; the throughput.
+            </p>
+          </article>
+          <article className="cap reveal">
+            <span className="cap-num">03 / Ship</span>
+            <CapArrow />
+            <h3>Production from day one.</h3>
+            <p className="cap-desc">
+              Every commit deploys. No staging-forever environments &mdash; real users,
+              real load, measured from the first week.
+            </p>
+          </article>
+          <article className="cap reveal">
+            <span className="cap-num">04 / Iterate</span>
+            <CapArrow />
+            <h3>Stay in the loop.</h3>
+            <p className="cap-desc">
+              We don&apos;t disappear at launch. Monthly cadence, real metrics, the
+              kind of partner you keep on speed dial.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      {/* SELECTED WORK */}
+      <section className="section" id="work" style={{ paddingTop: 0 }}>
+        <div className="section-head">
+          <span className="label">&sect; Selected work</span>
+          <h2>
+            Built in <em>production</em>. Not in a deck.
+          </h2>
+          <p className="aside">
+            A small selection of the studio&apos;s recent work. Full case studies on
+            request.
+          </p>
+        </div>
+        <div className="work">
+          {/* Live Carrier Rates */}
+          <article className="case reveal">
+            <div className="case-frame case-frame--carrier">
+              <div className="window-bar">
+                <div className="dots">
+                  <span />
+                  <span />
+                  <span />
+                </div>
+                <div className="url">checkout.acme-store.com</div>
+              </div>
+              <div className="checkout">
+                <div className="checkout-title">
+                  Shipping <small>Step 2 of 3</small>
+                </div>
+                <div className="rate">
+                  <div>
+                    <strong>USPS Ground Advantage &middot; 3&ndash;5 day tracked</strong>
+                    <div className="rate-eta">Arrives Mon 25 May</div>
+                  </div>
+                  <div className="rate-price">$4.85</div>
+                </div>
+                <div className="rate rate--active">
+                  <div>
+                    <strong>FedEx Priority Overnight &middot; before 12:00</strong>
+                    <div className="rate-eta">Arrives Wed 20 May</div>
+                  </div>
+                  <div className="rate-price">$24.40</div>
+                </div>
+                <div className="rate">
+                  <div>
+                    <strong>Australia Post &middot; Express 2 day</strong>
+                    <div className="rate-eta">Arrives Thu 21 May</div>
+                  </div>
+                  <div className="rate-price">$7.60</div>
+                </div>
+                <div className="rate">
+                  <div>
+                    <strong>DHL Express Worldwide</strong>
+                    <div className="rate-eta">Arrives Fri 22 May</div>
+                  </div>
+                  <div className="rate-price">$32.50</div>
+                </div>
+              </div>
+            </div>
+            <div className="case-meta">
+              <span className="case-status">
+                <span className="dot" /> Live
+              </span>
+              <div />
+              <h3 className="case-name">Live Carrier Rates</h3>
+              <p className="case-desc">
+                A published Shopify app that surfaces real-time carrier pricing
+                inside checkout &mdash; the moment shoppers decide to buy or bail.
+              </p>
+              <a
+                className="case-link"
+                href="https://apps.shopify.com/live-carrier-rates"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View on the Shopify App Store <ArrowRight />
+              </a>
+            </div>
+          </article>
+
+          {/* SKU Manager */}
+          <article className="case reveal">
+            <div className="case-frame case-frame--sku">
+              <div className="window-bar">
+                <div className="dots">
+                  <span />
+                  <span />
+                  <span />
+                </div>
+                <div className="url">app.skumanager.com &mdash; Catalog</div>
+              </div>
+              <div className="dash">
+                <div className="dash-head">
+                  12,408 SKUs <small>Updated 3 min ago</small>
+                </div>
+                <div className="dash-table">
+                  <div className="th">SKU</div>
+                  <div className="th">Variant</div>
+                  <div className="th">Stock</div>
+                  <div className="th">Status</div>
+                  <div className="td">NSF-1184-BLK</div>
+                  <div className="td">Standard</div>
+                  <div className="td">412</div>
+                  <div className="td">
+                    <span className="pill pill--live">Live</span>
+                  </div>
+                  <div className="td">NSF-2210-GRY</div>
+                  <div className="td">Premium</div>
+                  <div className="td">38</div>
+                  <div className="td">
+                    <span className="pill pill--live">Live</span>
+                  </div>
+                  <div className="td">NSF-9001-EVG</div>
+                  <div className="td">Limited</div>
+                  <div className="td">0</div>
+                  <div className="td">
+                    <span className="pill pill--draft">Draft</span>
+                  </div>
+                  <div className="td">NSF-4470-RED</div>
+                  <div className="td">Standard</div>
+                  <div className="td">1,204</div>
+                  <div className="td">
+                    <span className="pill pill--live">Live</span>
+                  </div>
+                  <div className="td">NSF-7732-CRM</div>
+                  <div className="td">Bundle</div>
+                  <div className="td">29</div>
+                  <div className="td">
+                    <span className="pill pill--live">Live</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="case-meta">
+              <span className="case-status">
+                <span className="dot" /> Live
+              </span>
+              <div />
+              <h3 className="case-name">SKU Manager</h3>
+              <p className="case-desc">
+                Operations tooling for merchandising teams running complex
+                catalogues at scale. Built for the businesses where product data
+                is the business.
+              </p>
+              <a
+                className="case-link"
+                href="https://skumanager.com"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Visit skumanager.com <ArrowRight />
+              </a>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* PROCESS */}
+      <section className="process-section" id="process">
+        <div className="process-inner">
+          <div className="section-head">
+            <span className="label">&sect; How we work</span>
+            <h2>
+              Four weeks, <em>not</em> four months.
+            </h2>
+            <p className="aside">
+              Most engagements run 4&ndash;12 weeks. We rebuild this timeline
+              together at the start.
+            </p>
+          </div>
+          <div className="timeline">
+            <article className="step reveal">
+              <span className="step-num">Week 01</span>
+              <p>
+                We map the system, the team, and the constraints. Output: one
+                page that everyone signs.
+              </p>
+              <h4>
+                Frame the <em>real</em> problem.
+              </h4>
+            </article>
+            <article className="step reveal">
+              <span className="step-num">Week 02</span>
+              <p>
+                First commit on day two. By Friday it&apos;s in front of users &mdash;
+                even if rough.
+              </p>
+              <h4>Ship something that runs.</h4>
+            </article>
+            <article className="step reveal">
+              <span className="step-num">Week 03</span>
+              <p>
+                Measure, cut, sharpen. AI handles the boilerplate so humans do
+                the judgement work.
+              </p>
+              <h4>
+                Refine in <em>public</em>.
+              </h4>
+            </article>
+            <article className="step reveal">
+              <span className="step-num">Week 04+</span>
+              <p>
+                Permanent ownership transfer or a monthly retainer &mdash; your call,
+                every quarter.
+              </p>
+              <h4>Hand over, or stay close.</h4>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      {/* PULL QUOTE */}
+      <section className="pullquote" id="about">
+        <blockquote className="reveal">
+          &ldquo;NITSOF cut our expected delivery timeline in <em>half</em>. The
+          AI-first approach isn&apos;t a pitch &mdash; it&apos;s just how they actually work,
+          every day, every meeting.&rdquo;
+        </blockquote>
+        <div className="attribution reveal">
+          <div className="name">James Harlow</div>
+          <div className="role">CTO &middot; Apex Logistics Group</div>
+          <div className="others">
+            <div className="o">
+              <span>Priya Mehta</span>
+              <span>Stackborn</span>
+            </div>
+            <div className="o">
+              <span>Daniel Osei</span>
+              <span>Mercia Health</span>
+            </div>
+            <div className="o" style={{ border: 0 }}>
+              <span>Maya Lindgren</span>
+              <span>Nordpath Retail</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* INSIGHTS PREVIEW */}
+      <section className="insights-preview" id="insights">
+        <div className="insights-section-label reveal">&sect; Insights</div>
+        <h2 className="insights-section-heading reveal">
+          Thinking out loud
+          <br />
+          on software &amp; <em>craft</em>.
+        </h2>
+        <div className="insights-grid">
+          {insights.map((post) => (
+            <Link
+              key={post.slug}
+              className="insight-card reveal"
+              href={`/insights/${post.slug}`}
+            >
+              <span className="insight-cat">{post.category}</span>
+              <h3 className="insight-title">{post.title}</h3>
+              <p className="insight-excerpt">{post.excerpt}</p>
+              <span className="insight-meta">
+                {new Date(post.date).toLocaleDateString("en-AU", {
+                  month: "long",
+                  year: "numeric",
+                })}
+              </span>
+            </Link>
+          ))}
+        </div>
+        <Link className="insights-all" href="/insights">
+          All insights <ArrowRight />
+        </Link>
+      </section>
+
+      {/* CTA / CONTACT */}
+      <section className="cta-section" id="contact">
+        <div className="cta-card">
+          <div className="reveal">
+            <h2>
+              Have something you&apos;d ship if it were <em>easy</em>?
+            </h2>
+            <p className="cta-lead">
+              Tell us what you&apos;re trying to build. We respond within one working
+              day &mdash; with either a plan or an honest reason why we&apos;re not the
+              right studio for it.
+            </p>
+            <p className="cta-direct">
+              Or email us directly:{" "}
+              <a href="mailto:hello@nitsof.com">hello@nitsof.com</a>
+            </p>
+          </div>
+          <div className="reveal">
+            <ContactForm />
+          </div>
+        </div>
+      </section>
+    </>
   );
 }

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+
+export default function ContactForm() {
+  const [submitted, setSubmitted] = useState(false);
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    const name = (data.get("name") as string) || "";
+    const company = (data.get("company") as string) || "";
+    const message = (data.get("message") as string) || "";
+    const body = [
+      `Name: ${name}`,
+      company ? `Company: ${company}` : "",
+      "",
+      message,
+    ]
+      .filter(Boolean)
+      .join("\n");
+    window.location.href = `mailto:hello@nitsof.com?subject=${encodeURIComponent(
+      "Project Brief — " + name
+    )}&body=${encodeURIComponent(body)}`;
+    setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <div className="cta-success" style={{ display: "block" }}>
+        Message sent — we&apos;ll be in touch within one working day.
+      </div>
+    );
+  }
+
+  return (
+    <form className="cta-form" onSubmit={handleSubmit}>
+      <div className="cta-field">
+        <label htmlFor="cf-name">Your name</label>
+        <input
+          id="cf-name"
+          name="name"
+          type="text"
+          placeholder="Alex Chen"
+          required
+          autoComplete="name"
+        />
+      </div>
+      <div className="cta-field">
+        <label htmlFor="cf-company">Company or website</label>
+        <input
+          id="cf-company"
+          name="company"
+          type="text"
+          placeholder="acmecorp.com"
+          autoComplete="organization"
+        />
+      </div>
+      <div className="cta-field">
+        <label htmlFor="cf-message">What are you trying to build?</label>
+        <textarea
+          id="cf-message"
+          name="message"
+          placeholder="We need to ship X by Y and our current approach isn't working because…"
+          required
+        />
+      </div>
+      <button className="cta-submit" type="submit">
+        Send brief
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M5 12h14M13 5l7 7-7 7" />
+        </svg>
+      </button>
+    </form>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,21 +1,62 @@
-import Link from "next/link";
-
 export default function Footer() {
+  const year = new Date().getFullYear();
+
   return (
-    <footer className="relative z-10 border-t border-gray-800 bg-black/50">
-      <div className="mx-auto max-w-7xl py-12 px-4 sm:px-6 lg:px-8">
-        <div className="md:flex md:items-center md:justify-between">
-          <div className="flex justify-center space-x-6 md:order-2">
-            <Link href="/privacy" className="text-gray-400 hover:text-white">
-              Privacy
-            </Link>
-          </div>
-          <div className="mt-8 md:order-1 md:mt-0">
-            <p className="text-center text-base text-gray-400">
-              &copy; {new Date().getFullYear()} NITSOF. All rights reserved.
-            </p>
-          </div>
-        </div>
+    <footer className="site-footer">
+      <span className="footer-flag">
+        {/* Australian flag */}
+        <svg
+          width="14"
+          height="11"
+          viewBox="0 0 14 11"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <rect width="14" height="11" rx="1" fill="#00008B" />
+          <line x1="0" y1="0" x2="14" y2="11" stroke="white" strokeWidth="1.8" />
+          <line x1="14" y1="0" x2="0" y2="11" stroke="white" strokeWidth="1.8" />
+          <line x1="0" y1="0" x2="14" y2="11" stroke="#CC0000" strokeWidth="1" />
+          <line x1="14" y1="0" x2="0" y2="11" stroke="#CC0000" strokeWidth="1" />
+          <rect y="4" width="14" height="3" fill="white" />
+          <rect x="5.5" y="0" width="3" height="11" fill="white" />
+          <rect y="4.5" width="14" height="2" fill="#CC0000" />
+          <rect x="6" y="0" width="2" height="11" fill="#CC0000" />
+        </svg>
+        Made in Australia
+      </span>
+
+      <span>
+        &copy; {year} NITSOF &middot;{" "}
+        <a href="/privacy">Privacy</a> &middot;{" "}
+        <a href="mailto:hello@nitsof.com">hello@nitsof.com</a>
+      </span>
+
+      <div className="footer-social">
+        <a
+          href="https://linkedin.com/company/nitsof"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="LinkedIn"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
+            <rect x="2" y="9" width="4" height="12" />
+            <circle cx="4" cy="4" r="2" />
+          </svg>
+          LinkedIn
+        </a>
+        <a
+          href="https://github.com/nitsof"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="GitHub"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
+          </svg>
+          GitHub
+        </a>
       </div>
     </footer>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,6 +10,7 @@ const navLinks = [
   { href: "/#services", label: "Services" },
   { href: "/#portfolio", label: "Portfolio" },
   { href: "/#about", label: "About" },
+  { href: "/insights", label: "Insights" },
 ];
 
 export default function Header() {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,90 +2,88 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
-import { usePathname } from "next/navigation";
 
 const navLinks = [
-  { href: "/", label: "Home" },
-  { href: "/#services", label: "Services" },
-  { href: "/#portfolio", label: "Portfolio" },
-  { href: "/#about", label: "About" },
+  { href: "#work", label: "Work" },
+  { href: "#capabilities", label: "Capabilities" },
+  { href: "#process", label: "Process" },
+  { href: "#about", label: "Studio" },
   { href: "/insights", label: "Insights" },
 ];
 
 export default function Header() {
-  const [isOpen, setIsOpen] = useState(false);
-  const pathname = usePathname();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const closeMenu = () => setMenuOpen(false);
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-black/50 backdrop-blur-sm">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex h-16 items-center justify-between">
-          <div className="flex-shrink-0">
-            <Link href="/">
-              <Image
-                src="/images/logo-graphic.png"
-                alt="NITSOF Logo"
-                width={40}
-                height={40}
-                className="h-10 w-10"
-              />
-            </Link>
-          </div>
-          <div className="hidden md:block">
-            <div className="ml-10 flex items-baseline space-x-4">
-              {navLinks.map((link) => {
-                const isActive = pathname === link.href;
-                return (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    className={`rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-                      isActive
-                        ? "bg-gray-800 text-white"
-                        : "text-gray-300 hover:bg-gray-700 hover:text-white"
-                    }`}
-                  >
-                    {link.label}
-                  </Link>
-                );
-              })}
-            </div>
-          </div>
-          <div className="-mr-2 flex md:hidden">
-            <button
-              onClick={() => setIsOpen(!isOpen)}
-              type="button"
-              className="inline-flex items-center justify-center rounded-md bg-gray-800 p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800"
-              aria-controls="mobile-menu"
-              aria-expanded="false"
-            >
-              <span className="sr-only">Open main menu</span>
-              {isOpen ? (
-                <svg className="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              ) : (
-                <svg className="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-              )}
-            </button>
-          </div>
-        </div>
-      </div>
+    <>
+      <header className="site-nav">
+        <Link className="wordmark" href="/" onClick={closeMenu}>
+          NITSOF<span className="wordmark-dot" aria-hidden="true" />
+        </Link>
 
-      {isOpen && (
-        <div className="md:hidden" id="mobile-menu">
-          <div className="space-y-1 px-2 pt-2 pb-3 sm:px-3">
-            {navLinks.map((link) => (
-              <Link key={link.href} href={link.href} className="block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">
-                {link.label}
-              </Link>
-            ))}
-          </div>
-        </div>
-      )}
-    </header>
+        <nav className="nav-links">
+          {navLinks.map((link) => (
+            <a key={link.href} href={link.href}>
+              {link.label}
+            </a>
+          ))}
+        </nav>
+
+        <a className="nav-cta" href="#contact">
+          Start a project
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M5 12h14M13 5l7 7-7 7" />
+          </svg>
+        </a>
+
+        <button
+          className={`hamburger${menuOpen ? " open" : ""}`}
+          onClick={() => setMenuOpen((v) => !v)}
+          aria-label={menuOpen ? "Close menu" : "Open menu"}
+          aria-expanded={menuOpen}
+        >
+          <span />
+          <span />
+          <span />
+        </button>
+      </header>
+
+      <nav
+        className={`mobile-menu${menuOpen ? " open" : ""}`}
+        aria-hidden={!menuOpen}
+      >
+        {navLinks.map((link) => (
+          <a key={link.href} href={link.href} onClick={closeMenu}>
+            {link.label}
+          </a>
+        ))}
+        <a className="menu-cta" href="#contact" onClick={closeMenu}>
+          Start a project
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M5 12h14M13 5l7 7-7 7" />
+          </svg>
+        </a>
+      </nav>
+    </>
   );
 }

--- a/src/components/PageAnimations.tsx
+++ b/src/components/PageAnimations.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function PageAnimations() {
+  useEffect(() => {
+    // Scroll progress bar
+    const bar = document.getElementById("scroll-progress");
+    const updateProgress = () => {
+      if (!bar) return;
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      bar.style.width = total > 0 ? (window.scrollY / total) * 100 + "%" : "0%";
+    };
+    window.addEventListener("scroll", updateProgress, { passive: true });
+
+    // Reveal on scroll
+    const reveals = document.querySelectorAll(".reveal");
+    const revealObserver = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            e.target.classList.add("in");
+            revealObserver.unobserve(e.target);
+          }
+        }
+      },
+      { rootMargin: "-8% 0px -8% 0px", threshold: 0.05 }
+    );
+    reveals.forEach((el) => revealObserver.observe(el));
+
+    // Hero → body transition via the .bridge element
+    const bridge = document.querySelector(".bridge");
+    const heroObserver = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          document.body.classList.toggle(
+            "past-hero",
+            !e.isIntersecting || e.boundingClientRect.top < 0
+          );
+        }
+      },
+      { threshold: 0 }
+    );
+    if (bridge) heroObserver.observe(bridge);
+
+    return () => {
+      window.removeEventListener("scroll", updateProgress);
+      revealObserver.disconnect();
+      heroObserver.disconnect();
+    };
+  }, []);
+
+  return null;
+}

--- a/src/content/insights/ai-native-delivery.md
+++ b/src/content/insights/ai-native-delivery.md
@@ -1,0 +1,46 @@
+---
+title: "Why AI-native delivery cuts timelines in half — and what most teams miss"
+slug: ai-native-delivery
+date: "2026-05-01"
+author: NITSOF Team
+category: Engineering
+excerpt: "The models aren't the bottleneck. The missing piece is changing how you scope, review, and ship. Here's what two years of AI-first projects taught us."
+---
+
+Two years ago, the conversation was about whether AI could write useful code at all. Today, every team claims to be "using AI." The results are wildly uneven — and the gap has nothing to do with which model you're using.
+
+## The real constraint isn't the model
+
+Most teams adopt AI as a faster typist. They keep the same planning cycles, the same review process, the same deployment cadence — and then wonder why they're only 20% faster instead of 2x.
+
+The leverage isn't in generation speed. It's in **decision latency**: how quickly can you validate whether a direction is right?
+
+AI dramatically compresses the cost of trying something. If the cost of a prototype is four hours instead of four days, the question becomes whether you're generating enough prototypes — and whether your process is set up to throw the wrong ones away quickly.
+
+## What changes in an AI-native workflow
+
+In a conventional workflow, you spend time deciding before you build. Architecture meetings, spec documents, design reviews. All valuable — but expensive, because the cost of rework is high.
+
+In an AI-native workflow, the cost of rework drops. That changes the optimal trade-off:
+
+- **Scope tighter, ship sooner.** A working vertical slice beats a complete design document. Ship to staging after day two, not week two.
+- **Review differently.** AI-generated code needs to be read for correctness and intent, not just structure. Your reviewers need to understand what it's *trying* to do, not just that it compiles.
+- **Iterate in days, not sprints.** The two-week sprint was designed around the cost of switching context. When iteration is cheap, you can run tighter loops.
+
+## The thing most teams get wrong
+
+They treat AI as a tool for individual developers to go faster, rather than as a capability that changes how the team works together.
+
+The biggest wins we've seen aren't from an engineer who is personally faster. They're from teams that restructured the handoffs between design, engineering, and QA around the assumption that working code would be available earlier in the process.
+
+When the designer can react to a working prototype instead of a wireframe, the feedback is qualitatively different. When QA can run against a working branch from day three, the test cases they write are more useful. The AI speed-up at the individual level compounds into a structural shift at the team level.
+
+## What this means for your next project
+
+If you're trying to adopt AI-native delivery, start with one question: **what is the first working thing your stakeholders can react to, and how quickly can you put it in front of them?**
+
+Push that date as early as you possibly can. That constraint will tell you everything you need to change about your process.
+
+---
+
+*NITSOF builds software for businesses that can't afford to move at the pace of a traditional agency. If you're working out how to apply AI to a real delivery challenge, [get in touch](/contact).*

--- a/src/content/insights/from-prototype-to-production.md
+++ b/src/content/insights/from-prototype-to-production.md
@@ -1,0 +1,58 @@
+---
+title: "From prototype to production in four weeks — the NITSOF method"
+slug: from-prototype-to-production
+date: "2026-03-18"
+author: NITSOF Team
+category: Studio
+excerpt: "Four weeks isn't a sprint. It's a constraint that forces the right decisions early. This is how we structure engagements so nothing important gets built twice."
+---
+
+Four weeks sounds aggressive. For a meaningful piece of software — something with real users, real data, and a real business on the line — it sounds impossible.
+
+It's not. But it requires treating the four-week constraint as a design principle, not a deadline.
+
+## Why four weeks works
+
+The most expensive thing in software development is rework: building something, showing it to a stakeholder, and being told it's wrong. The longer the feedback loop, the more expensive the rework.
+
+Traditional agency engagements often have a six-to-eight week discovery phase before a single line of production code gets written. By the time you show the client something real, the mental model on both sides has already calcified around the spec — and the spec is always wrong.
+
+Four weeks changes the feedback economics. If the cycle is short enough, you can afford to be wrong early. You can prototype a direction, show it to real users, and pivot without sinking months of work.
+
+## How we structure the four weeks
+
+**Week 1 — Scope and scaffold**
+
+We don't write a requirements document. We build the thing that the rest of the project is about: the core user action. If it's a Shopify app, we build the install flow and the one screen that does the main job. If it's an internal tool, we build the thing an operator will do fifty times a day.
+
+Getting this in front of a real user by day five tells us more than two weeks of discovery calls.
+
+**Week 2 — The hard part**
+
+Week two is where most projects either save themselves or go wrong. The hard part is usually something technical (an API that doesn't work the way the docs said, a data model that can't represent the edge cases) or something product-level (users don't use the feature the way we thought).
+
+We surface this in week two because there's still time to respond. Week three is too late.
+
+**Week 3 — Completeness**
+
+Week three is about filling in what the core doesn't cover: error states, edge cases, mobile, accessibility, the things that aren't visible in a demo but matter when a thousand people use it.
+
+This is also when we write the tests that let us change things in week four without breaking what's already working.
+
+**Week 4 — Ship**
+
+Week four is launch. Not "feature-complete." Not "code freeze." Launch — to real users, in a real environment.
+
+The features that didn't make it into four weeks go on the backlog. They're almost always the right things to cut.
+
+## What makes this possible
+
+Two things make four weeks work:
+
+**Opinionated tooling decisions made early.** We don't spend week one evaluating database options. We make the call on day one and move. The cost of a wrong tooling decision is lower than the cost of tooling paralysis.
+
+**Stakeholder access, not stakeholder meetings.** Four weeks doesn't leave room for a weekly status call with a two-week feedback cycle. We need someone on the client side who can answer a question in an hour and make a decision in a day. If that person doesn't exist, the timeline doesn't work.
+
+---
+
+*If you have something you need to ship and you're tired of timelines that keep slipping, [let's talk](/contact). We're direct about what's achievable in four weeks and what isn't.*

--- a/src/content/insights/shopify-shipping-complexity.md
+++ b/src/content/insights/shopify-shipping-complexity.md
@@ -1,0 +1,58 @@
+---
+title: "The hidden complexity behind Shopify shipping rates"
+slug: shopify-shipping-complexity
+date: "2026-04-10"
+author: NITSOF Team
+category: Product
+excerpt: "Building Live Carrier Rates taught us that 'show the right price at checkout' is deceptively hard. Carrier APIs, real-time latency, and Shopify's rate model all conspire against you."
+---
+
+"We just need to show live shipping rates at checkout." This is how almost every Live Carrier Rates conversation starts. It sounds simple. It is not.
+
+After shipping [Live Carrier Rates](https://apps.shopify.com/live-carrier-rates) and watching merchants use it in production, here is what we learned about the hidden complexity of Shopify shipping.
+
+## Shopify's rate model is unusual
+
+Most e-commerce platforms calculate shipping after the fact — you show an estimated price and reconcile later. Shopify does the opposite: it calls your rate provider at checkout *before* the customer commits to the order. The rate you return is the rate they pay.
+
+That creates a strict contract. Your app has to:
+
+1. Receive a cart payload (weights, dimensions, destination)
+2. Query one or more carrier APIs in real time
+3. Return valid, parseable rate objects
+4. Do all of this in under five seconds or Shopify times out
+
+Miss the five-second window and the customer sees an error. Return a wrong rate and the merchant eats the difference.
+
+## Carrier APIs are not designed for this
+
+Every major carrier — Australia Post, FedEx, DHL, USPS — has a different API, a different authentication model, a different schema for rate requests. They were designed to be called by shipping software at label-creation time, not by a checkout page in real time.
+
+The variability is enormous:
+
+- Some carriers return errors as HTTP 200 responses with an error field in the body
+- Some have rate limits that trigger under normal checkout traffic
+- Response times vary from 200ms to 3.5 seconds depending on the carrier and time of day
+- Some carrier APIs go down completely — you need a graceful fallback
+
+## The latency problem
+
+Checking rates from a single carrier is straightforward. Checking rates from three or four carriers in parallel, within five seconds, while handling carrier timeouts gracefully, is an architecture problem.
+
+We spent significant time on:
+
+- **Parallel requests with timeout budgets** — if a carrier doesn't respond in 3 seconds, skip it and return whatever we have
+- **Caching rate lookups** — same cart, same destination, same weight = same rates for 90 seconds, dramatically reducing carrier API calls
+- **Circuit breakers** — if a carrier is failing repeatedly, stop calling it until it recovers
+
+## What merchants actually need
+
+The technical complexity matters only because of what's on the other side: a customer deciding whether to complete a purchase. Surprising shipping costs at checkout are the number-one reason for cart abandonment.
+
+When shipping rates are accurate and live, merchants stop padding their flat rates with a buffer "just in case." That buffer is often the margin that makes or breaks a sale.
+
+The best outcome is invisible: the customer sees an accurate price, pays it, and never thinks about it again. That's what we built Live Carrier Rates to do.
+
+---
+
+*Live Carrier Rates is available on the [Shopify App Store](https://apps.shopify.com/live-carrier-rates). If you're building a Shopify app and want to talk through architecture challenges, [we'd love to hear from you](/contact).*

--- a/src/lib/insights.ts
+++ b/src/lib/insights.ts
@@ -1,0 +1,49 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import { marked } from "marked";
+
+const CONTENT_DIR = path.join(process.cwd(), "src/content/insights");
+
+export interface InsightMeta {
+  slug: string;
+  title: string;
+  date: string;
+  author: string;
+  category: string;
+  excerpt: string;
+}
+
+export interface InsightPost extends InsightMeta {
+  content: string;
+}
+
+export function getAllInsights(): InsightMeta[] {
+  const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".md"));
+  return files
+    .map((filename) => {
+      const raw = fs.readFileSync(path.join(CONTENT_DIR, filename), "utf-8");
+      const { data } = matter(raw);
+      return data as InsightMeta;
+    })
+    .sort((a, b) => (a.date < b.date ? 1 : -1));
+}
+
+export function getInsightBySlug(slug: string): InsightPost | null {
+  const filepath = path.join(CONTENT_DIR, `${slug}.md`);
+  if (!fs.existsSync(filepath)) return null;
+  const raw = fs.readFileSync(filepath, "utf-8");
+  const { data, content } = matter(raw);
+  return {
+    ...(data as InsightMeta),
+    content: marked(content) as string,
+  };
+}
+
+export function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-AU", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}


### PR DESCRIPTION
## Summary

Ports the approved **hybrid design direction** (dark hero → warm cream body) from the HTML preview into the live Next.js/React codebase. All changes agreed through the NIT-11 review thread are included.

### What's in this PR

**Design system**
- New `globals.css`: full hybrid token system (cream/ink/cobalt/signal palette), all component CSS classes, animation classes, `past-hero` CSS transitions, and print/accessibility rules
- FontShare fonts (General Sans + Switzer) loaded via `<link>` in layout; JetBrains Mono from Google Fonts

**Homepage (`page.tsx`)**
- Ticker strip, dark full-viewport hero with stat bar, gradient bridge
- Trusted-by client strip → 3-principle manifesto → 4-capability grid → 2-up work cases → 4-step process timeline → pull quote → insights preview → CTA contact section

**Product details**
- Live Carrier Rates: links to https://apps.shopify.com/live-carrier-rates
- SKU Manager: links to https://skumanager.com
- Carrier mock: USPS / FedEx / Australia Post / DHL — `$` pricing throughout, no `£`
- Hero location: `Australia · Worldwide`

**Components**
- `Header.tsx`: hybrid sticky nav — dark on hero, flips to cream on scroll; wordmark with cobalt dot; hamburger mobile menu
- `Footer.tsx`: LinkedIn + GitHub social links, Made in Australia flag, `hello@nitsof.com`
- `PageAnimations.tsx` *(new)*: client component — scroll progress bar (cobalt, 2px), IntersectionObserver reveal animations, `past-hero` body class toggling
- `ContactForm.tsx` *(new)*: client form — Name / Company / What are you building? — prefills `mailto:hello@nitsof.com` on submit, shows success state

**Insights section**
- `/insights` and `/insights/[slug]` restyled to match cream hybrid theme
- Existing 3 markdown posts (ai-native-delivery, shopify-shipping-complexity, from-prototype-to-production) unchanged and building correctly

**Favicon**: N· SVG mark (near-black square, cream N, cobalt dot) — already on branch, confirmed correct

**Metadata**: title, description, OG, Twitter card updated; `themeColor` moved to `viewport` export per Next.js 15 requirement

## Build

```
✓ Compiled successfully
✓ 12/12 static pages generated
✓ No type errors, no lint errors
```

## Test plan

- [ ] `npm run dev` → open `http://localhost:3000` — verify dark hero + cream body
- [ ] Scroll through hero → confirm nav and grain overlay transition
- [ ] Check mobile at ≤760px → hamburger opens full-screen dark menu
- [ ] Verify `/insights` list page and individual post pages render in cream theme
- [ ] Submit contact form → verify mailto pre-fill with correct address
- [ ] Confirm carrier rates link goes to Shopify App Store listing
- [ ] Confirm skumanager.com link works
- [ ] Run `npm run build` → clean output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Insights section with blog articles and posts
  * Introduced contact form for user inquiries
  * Implemented scroll-triggered page animations and visual effects

* **Style**
  * Complete design system refresh with updated color scheme and typography
  * Redesigned navigation header and footer layouts
  * Enhanced visual hierarchy with new component styling

* **Documentation**
  * Added brand refresh preview materials

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nitsof/nitsof.com/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->