### PR TITLE
fix: add force-static export to sitemap and robots routes

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,7 @@
 import type { MetadataRoute } from "next";
 
+export const dynamic = "force-static";
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: { userAgent: "*", allow: "/" },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,7 @@
 import type { MetadataRoute } from "next";
 
+export const dynamic = "force-static";
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = "https://nitsof.com";
   const defaultLastModified = new Date("2026-05-17T00:00:00.000Z");


### PR DESCRIPTION
## Summary
- Adds `export const dynamic = "force-static"` to `src/app/sitemap.ts` and `src/app/robots.ts`
- Fixes the build failure caused by Next.js `output: export` requiring this directive on route handlers for `/sitemap.xml` and `/robots.txt`

## Root cause
Next.js static HTML export (`output: export`) requires all route handlers to explicitly declare `export const dynamic = "force-static"` or set `export const revalidate`. The sitemap and robots metadata routes were missing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)