### PR TITLE
Wire up contact form Formspree ID in CI build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Formspree form ID for the contact form on the home page.
+# Create a form at https://formspree.io, then copy the form ID (e.g. xabc1234).
+# For local development: copy this file to .env.local and fill in the value.
+# For GitHub Pages deployment: add FORMSPREE_ID as a repository secret in
+#   Settings → Secrets and variables → Actions.
+NEXT_PUBLIC_FORMSPREE_ID=

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -75,6 +75,8 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
+        env:
+          NEXT_PUBLIC_FORMSPREE_ID: ${{ secrets.FORMSPREE_ID }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary

- Injects `NEXT_PUBLIC_FORMSPREE_ID` from the `FORMSPREE_ID` GitHub repository secret into the `next build` step so the contact form POSTs to Formspree instead of falling back to the mailto link
- Adds `.env.example` documenting the required env variable
- Unignores `.env.example` from the `.env*` gitignore rule

## How the form works (no code changes needed)

`ContactForm.tsx` already has the full Formspree implementation with success/error states and a mailto fallback. The only missing piece was the build-time secret injection, which this PR adds.

## Activation steps (repo owner)

1. Create a form at https://formspree.io
2. Add the form ID (e.g. `xabc1234`) as a repository secret named `FORMSPREE_ID`  
   → Settings → Secrets and variables → Actions → New repository secret
3. Re-run the GitHub Pages deployment — the contact form will then submit to Formspree

## Test plan

- [ ] After configuring `FORMSPREE_ID` secret, trigger a new GitHub Pages build
- [ ] Submit the contact form on the live site — should show "Message sent" success state
- [ ] Check Formspree dashboard for received submission
- [ ] Verify no regressions on existing page content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Formspree contact form support with configurable form ID through environment variables, enabling flexible deployment across local development and production environments.

* **Chores**
  * Updated GitHub Actions workflow to handle contact form configuration during the build process.
  * Improved environment file management to securely handle configuration while maintaining setup documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nitsof/nitsof.com/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->