### PR TITLE
feat: wire up contact form (NIT-16)

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -22,6 +22,7 @@ export default function ContactForm() {
         });
         if (res.ok) {
           setStatus("success");
+          form.reset();
         } else {
           setStatus("error");
         }
@@ -31,10 +32,12 @@ export default function ContactForm() {
     } else {
       // Fallback: pre-fill a mailto link (works without a backend)
       const name = (data.get("name") as string) || "";
+      const email = (data.get("email") as string) || "";
       const company = (data.get("company") as string) || "";
       const message = (data.get("message") as string) || "";
       const body = [
         `Name: ${name}`,
+        email ? `Email: ${email}` : "",
         company ? `Company: ${company}` : "",
         "",
         message,
@@ -67,6 +70,17 @@ export default function ContactForm() {
           placeholder="Alex Chen"
           required
           autoComplete="name"
+        />
+      </div>
+      <div className="cta-field">
+        <label htmlFor="cf-email">Email address</label>
+        <input
+          id="cf-email"
+          name="email"
+          type="email"
+          placeholder="alex@acmecorp.com"
+          required
+          autoComplete="email"
         />
       </div>
       <div className="cta-field">


### PR DESCRIPTION
## Summary
- Added required email field to contact form so Formspree can set the reply-to address on submissions
- Form resets after a successful submission
- Email is also included in the mailto fallback body for environments without a Formspree ID

## How it works
The form submits to Formspree when `NEXT_PUBLIC_FORMSPREE_ID` is set in the deployment environment (Formspree is the right choice for this static GitHub Pages site). Without the env var, it falls back to opening the user's email client with a pre-filled body.

To fully activate submissions in production:
1. Create a form at [formspree.io](https://formspree.io)
2. Set `NEXT_PUBLIC_FORMSPREE_ID=<your-form-id>` in the GitHub Pages / deployment env

## Test plan
- [ ] Form renders with name, email, company, message fields
- [ ] Submit without email → browser validation blocks it
- [ ] Submit with all required fields → success state shown, form resets
- [ ] No regressions to other site sections

Closes NIT-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)