### PR TITLE
feat: wire up contact form with EmailJS (NIT-16)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# EmailJS credentials for the contact form.
+# Sign up at https://www.emailjs.com, create a service and template, then copy these values.
+# For local development: copy this file to .env.local and fill in the values.
+# For GitHub Pages deployment: add these as repository secrets in
+#   Settings → Secrets and variables → Actions.
+NEXT_PUBLIC_EMAILJS_SERVICE_ID=
+NEXT_PUBLIC_EMAILJS_TEMPLATE_ID=
+NEXT_PUBLIC_EMAILJS_PUBLIC_KEY=

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -75,6 +75,10 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
+        env:
+          NEXT_PUBLIC_EMAILJS_SERVICE_ID: ${{ secrets.EMAILJS_SERVICE_ID }}
+          NEXT_PUBLIC_EMAILJS_TEMPLATE_ID: ${{ secrets.EMAILJS_TEMPLATE_ID }}
+          NEXT_PUBLIC_EMAILJS_PUBLIC_KEY: ${{ secrets.EMAILJS_PUBLIC_KEY }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nitsof-website",
       "version": "0.1.0",
       "dependencies": {
+        "@emailjs/browser": "^4.4.1",
         "@tailwindcss/typography": "^0.5.19",
         "gray-matter": "^4.0.3",
         "marked": "^18.0.3",
@@ -54,6 +55,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@emailjs/browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-4.4.1.tgz",
+      "integrity": "sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@emailjs/browser": "^4.4.1",
     "@tailwindcss/typography": "^0.5.19",
     "gray-matter": "^4.0.3",
     "marked": "^18.0.3",

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import emailjs from "@emailjs/browser";
 
 export default function ContactForm() {
   const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
@@ -11,30 +12,38 @@ export default function ContactForm() {
 
     const form = e.currentTarget;
     const data = new FormData(form);
-    const formspreeId = process.env.NEXT_PUBLIC_FORMSPREE_ID;
 
-    if (formspreeId) {
+    const serviceId = process.env.NEXT_PUBLIC_EMAILJS_SERVICE_ID;
+    const templateId = process.env.NEXT_PUBLIC_EMAILJS_TEMPLATE_ID;
+    const publicKey = process.env.NEXT_PUBLIC_EMAILJS_PUBLIC_KEY;
+
+    if (serviceId && templateId && publicKey) {
       try {
-        const res = await fetch(`https://formspree.io/f/${formspreeId}`, {
-          method: "POST",
-          body: data,
-          headers: { Accept: "application/json" },
-        });
-        if (res.ok) {
-          setStatus("success");
-        } else {
-          setStatus("error");
-        }
+        await emailjs.send(
+          serviceId,
+          templateId,
+          {
+            from_name: (data.get("name") as string) || "",
+            from_email: (data.get("email") as string) || "",
+            company: (data.get("company") as string) || "",
+            message: (data.get("message") as string) || "",
+          },
+          publicKey
+        );
+        setStatus("success");
+        form.reset();
       } catch {
         setStatus("error");
       }
     } else {
       // Fallback: pre-fill a mailto link (works without a backend)
       const name = (data.get("name") as string) || "";
+      const email = (data.get("email") as string) || "";
       const company = (data.get("company") as string) || "";
       const message = (data.get("message") as string) || "";
       const body = [
         `Name: ${name}`,
+        email ? `Email: ${email}` : "",
         company ? `Company: ${company}` : "",
         "",
         message,
@@ -67,6 +76,17 @@ export default function ContactForm() {
           placeholder="Alex Chen"
           required
           autoComplete="name"
+        />
+      </div>
+      <div className="cta-field">
+        <label htmlFor="cf-email">Email address</label>
+        <input
+          id="cf-email"
+          name="email"
+          type="email"
+          placeholder="alex@acmecorp.com"
+          required
+          autoComplete="email"
         />
       </div>
       <div className="cta-field">


### PR DESCRIPTION
## Summary

- Replaces the incorrect Formspree implementation with EmailJS (`@emailjs/browser`), matching the pattern used on skumanager.com
- Adds `@emailjs/browser` as a dependency
- CI workflow injects three EmailJS secrets at build time: `EMAILJS_SERVICE_ID`, `EMAILJS_TEMPLATE_ID`, `EMAILJS_PUBLIC_KEY`
- Adds email field to the contact form so submissions carry a reply-to address
- `.env.example` documents the required vars for local development

## Setup required (repo owner)

1. Sign up / log in at https://www.emailjs.com
2. Create a service and an email template with these variables: `from_name`, `from_email`, `company`, `message`
3. Add three repository secrets (Settings → Secrets and variables → Actions):
   - `EMAILJS_SERVICE_ID`
   - `EMAILJS_TEMPLATE_ID`
   - `EMAILJS_PUBLIC_KEY`
4. Merge this PR and redeploy — the contact form will then send via EmailJS

Without the secrets, the form falls back to opening the user's email client pre-filled.

## Note

Closes / supersedes PRs #8 and #9 (both used Formspree incorrectly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)