### PR TITLE
Add Google Analytics GA4 tag (G-15C8MLCLC5)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { JetBrains_Mono } from "next/font/google";
 import localFont from "next/font/local";
+import Script from "next/script";
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
@@ -68,6 +69,18 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${jetbrainsMono.variable} ${generalSans.variable} ${switzer.variable}`}>
       <body>
+        <Script
+          strategy="afterInteractive"
+          src="https://www.googletagmanager.com/gtag/js?id=G-15C8MLCLC5"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-15C8MLCLC5');
+          `}
+        </Script>
         <div id="scroll-progress" aria-hidden="true" />
         <div className="grain-overlay" aria-hidden="true" />
         <HybridAnimations />


### PR DESCRIPTION
## Summary

- Adds Google Analytics GA4 tracking tag with measurement ID `G-15C8MLCLC5` to the site
- Uses `next/script` with `strategy="afterInteractive"` for optimal Next.js App Router integration
- Loads the gtag.js library and initialises the configuration inline

Closes NIT-17.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated Google Analytics tracking into the application to enable usage monitoring and performance insights.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nitsof/nitsof.com/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->